### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: ''
+assignees: andescu
+
+---
+
+### Describe the bug
+
+### Which version/tag/hash of the HERE OLP Edge SDK are you using?
+
+### What compiler are you using? What version of the compiler?
+
+### What are the CMake arguments?
+
+### Steps to reproduce the issue
+
+### Expected behavior
+
+### Can you provide any TRACE level logs?
+*Please strip sensitive data prior to upload!*


### PR DESCRIPTION
Updated issue template to provide users a clear structure of what information are relevant for us to reproduce and find the issue mentioned. The needed information that is necessary: the version of the SDK, the CMake flags, compiler with version, platform. Optional user can also upload trace logs.