### PR TITLE
Fixed CMake configuration errors of Android tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ html/
 # Visual Studio
 .vs/
 CMakeSettings.json
+
+# Android Studio
+!build.gradle*

--- a/cmake/android/tester/app/build.gradle.in
+++ b/cmake/android/tester/app/build.gradle.in
@@ -1,0 +1,29 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 23
+
+    defaultConfig {
+        applicationId "com.here.android.olp.@PACKAGE_NAME@"
+        minSdkVersion 15
+        targetSdkVersion 23
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    api 'com.android.support:appcompat-v7:23.0.1'
+    api 'com.android.support:support-annotations:24.0.0'
+    androidTestImplementation 'com.android.support:support-annotations:24.0.0'
+    androidTestImplementation 'com.android.support.test:runner:0.5'
+    androidTestImplementation 'com.android.support.test:rules:0.5'
+}

--- a/cmake/android/tester/build.gradle
+++ b/cmake/android/tester/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.1.3'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}


### PR DESCRIPTION
- fixed problems occurred when configuring Android test applications via CMake;
- added missing build.gradle files required for Android test applications;
- changed the global .gitignore file to support buid.gradle files

Resolves: OLPEDGE-355

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>