### PR TITLE
Fixed linker errors when using EDGE SDK in other HERE Android projects

### DIFF
--- a/olp-cpp-sdk-core/cmake/android.cmake
+++ b/olp-cpp-sdk-core/cmake/android.cmake
@@ -37,7 +37,7 @@ endif()
 
 set(NETWORK_VERSION 0.0.1)
 set(CMAKE_JAVA_COMPILE_FLAGS -source 1.7 -target 1.7)
-set(CMAKE_JAR_CLASSES_PREFIX com/here/network)
+set(CMAKE_JAR_CLASSES_PREFIX com/here/olp/network)
 set(EDGE_NETWORK_PROTOCOL_JAR EdgeNetworkProtocol)
 
 include(${CMAKE_CURRENT_LIST_DIR}/GetAndroidVariables.cmake)

--- a/olp-cpp-sdk-core/src/network/android/NetworkProtocol.java
+++ b/olp-cpp-sdk-core/src/network/android/NetworkProtocol.java
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package com.here.network;
+package com.here.olp.network;
 
 import android.annotation.SuppressLint;
 import android.net.SSLCertificateSocketFactory;

--- a/olp-cpp-sdk-core/src/network/android/NetworkProtocolAndroid.cpp
+++ b/olp-cpp-sdk-core/src/network/android/NetworkProtocolAndroid.cpp
@@ -239,7 +239,7 @@ bool NetworkProtocolAndroid::Initialize() {
   }
 
   /* Get the Network protocol class */
-  jstring className = env->NewStringUTF("com/here/network/NetworkProtocol");
+  jstring className = env->NewStringUTF("com/here/olp/network/NetworkProtocol");
   if (env->ExceptionOccurred()) {
     LOG_ERROR(LOGTAG, "initialize failed to create class name string");
     env->ExceptionDescribe();
@@ -273,7 +273,7 @@ bool NetworkProtocolAndroid::Initialize() {
   m_jmidSend = env->GetMethodID(
       m_class, "send",
       "(Ljava/lang/String;IIIII[Ljava/lang/String;[BZLjava/lang/"
-      "String;IILjava/lang/String;I)Lcom/here/network/"
+      "String;IILjava/lang/String;I)Lcom/here/olp/network/"
       "NetworkProtocol$GetTask;");
   if (env->ExceptionOccurred()) {
     LOG_ERROR(LOGTAG, "initialize failed to get NetworkProtocol::send");
@@ -1035,16 +1035,16 @@ NetworkProtocolAndroid::ResultData::ResultData(
 }  // namespace olp
 
 #ifndef __clang__
-#define OS_NETWORK_EXPORT __attribute__((externally_visible)) JNIEXPORT
+#define EDGE_SDK_NETWORK_EXPORT __attribute__((externally_visible)) JNIEXPORT
 #else
-#define OS_NETWORK_EXPORT JNIEXPORT
+#define EDGE_SDK_NETWORK_EXPORT JNIEXPORT
 #endif
 
 /*
  * Callback to be called when response headers have been received
  */
-extern "C" OS_NETWORK_EXPORT void JNICALL
-Java_com_here_network_NetworkProtocol_headersCallback(JNIEnv* env, jobject obj,
+extern "C" EDGE_SDK_NETWORK_EXPORT void JNICALL
+Java_com_here_olp_network_NetworkProtocol_headersCallback(JNIEnv* env, jobject obj,
                                                       jint clientId,
                                                       jint requestId,
                                                       jobjectArray headers) {
@@ -1059,8 +1059,8 @@ Java_com_here_network_NetworkProtocol_headersCallback(JNIEnv* env, jobject obj,
 /*
  * Callback to be called when a date header is received
  */
-extern "C" OS_NETWORK_EXPORT void JNICALL
-Java_com_here_network_NetworkProtocol_dateAndOffsetCallback(
+extern "C" EDGE_SDK_NETWORK_EXPORT void JNICALL
+Java_com_here_olp_network_NetworkProtocol_dateAndOffsetCallback(
     JNIEnv* env, jobject obj, jint clientId, jint requestId, jlong date,
     jlong offset) {
   auto protocol = olp::network::getProtocolForClient(clientId);
@@ -1075,8 +1075,8 @@ Java_com_here_network_NetworkProtocol_dateAndOffsetCallback(
 /*
  * Callback to be called when a chunk of data is received
  */
-extern "C" OS_NETWORK_EXPORT void JNICALL
-Java_com_here_network_NetworkProtocol_dataCallback(JNIEnv* env, jobject obj,
+extern "C" EDGE_SDK_NETWORK_EXPORT void JNICALL
+Java_com_here_olp_network_NetworkProtocol_dataCallback(JNIEnv* env, jobject obj,
                                                    jint clientId,
                                                    jint requestId,
                                                    jbyteArray data, jint len) {
@@ -1091,8 +1091,8 @@ Java_com_here_network_NetworkProtocol_dataCallback(JNIEnv* env, jobject obj,
 /*
  * Callback to be called when a request is completed
  */
-extern "C" OS_NETWORK_EXPORT void JNICALL
-Java_com_here_network_NetworkProtocol_completeRequest(
+extern "C" EDGE_SDK_NETWORK_EXPORT void JNICALL
+Java_com_here_olp_network_NetworkProtocol_completeRequest(
     JNIEnv* env, jobject obj, jint clientId, jint requestId, jint status,
     jstring error, jint maxAge, jint expires, jstring etag,
     jstring contentType) {
@@ -1108,8 +1108,8 @@ Java_com_here_network_NetworkProtocol_completeRequest(
 /*
  * Reset request upon retry
  */
-extern "C" OS_NETWORK_EXPORT void JNICALL
-Java_com_here_network_NetworkProtocol_resetRequest(JNIEnv* env, jobject obj,
+extern "C" EDGE_SDK_NETWORK_EXPORT void JNICALL
+Java_com_here_olp_network_NetworkProtocol_resetRequest(JNIEnv* env, jobject obj,
                                                    jint clientId,
                                                    jint requestId) {
   auto protocol = olp::network::getProtocolForClient(clientId);

--- a/olp-cpp-sdk-core/src/network/android/NetworkSSLContextFactory.java
+++ b/olp-cpp-sdk-core/src/network/android/NetworkSSLContextFactory.java
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package com.here.network;
+package com.here.olp.network;
 
 import android.net.SSLCertificateSocketFactory;
 import android.util.Log;

--- a/olp-cpp-sdk-core/src/network/ios/HttpClient.mm
+++ b/olp-cpp-sdk-core/src/network/ios/HttpClient.mm
@@ -181,7 +181,7 @@ static NSString* const kMosCACertificateMd5 = @"497904b0eb8719ac47b0bc11519b74d0
 
 - (void)customInit {
   _delegateQueue = [NSOperationQueue new];
-  _delegateQueue.name = @"com.here.networks.HttpClientSessionQueue";
+  _delegateQueue.name = @"com.here.olp.networks.HttpClientSessionQueue";
   // TODO: Any expert to write lambda here?
   const olp::network::NetworkSystemConfig& sysConfig =
       olp::network::Network::SystemConfig().lockedCopy();


### PR DESCRIPTION
- renamed the NetworkProtocol's package name from com.here.network to com.here.olp.network to avoid name collisions with other projects;
- changed JNI bindings and export macros to avoid symbols collisions

Resolves: OLPEDGE-359

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>