### PR TITLE
Fixed generation of tester apps when configuring SDK on iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 CMakeLists.txt.user
-build*
+build*/
 *.doap
 .repo
 

--- a/cmake/ios/gen_ios_test.cmake
+++ b/cmake/ios/gen_ios_test.cmake
@@ -20,12 +20,6 @@ function(gen_ios_test)
     endif()
 
     configure_file(
-        ${CMAKE_SOURCE_DIR}/cmake/ios/build_testapp.sh.in
-        ./build_testapp.sh
-        @ONLY
-    )
-
-    configure_file(
         ${CMAKE_SOURCE_DIR}/cmake/ios/ios_test.sh.in
         ./ios_test.sh
         @ONLY

--- a/cmake/ios/ios_test.sh.in
+++ b/cmake/ios/ios_test.sh.in
@@ -6,7 +6,7 @@
 ##                                                             --kpiTestRunCount=100
 ##                                                             --stressTestDuration=120"
 ##                                                             --runProdTests
-##      -b              - the build flag, YES to build APP, NO do not
+##      -b              - the build flag, YES to build APP, NO do not. Currently not supported.
 ##      -c <config>     - the build configuration, either debug or release (default)
 ##      -p <platform>   - the build platform, either iphoneos (default) or iphonesimulator
 ##
@@ -121,8 +121,10 @@ while getopts "a:b:c:p:h" opt; do
     a)
         ARGUMENTS=$OPTARG
         ;;
+
     b)
-        BUILD_FLAG=$OPTARG
+        ## Temporarily disabled until iOS build jobs will be configured
+        # BUILD_FLAG=$OPTARG
         ;;
     c)
         BUILD_CONFIG=$OPTARG


### PR DESCRIPTION
- Fixed CMake errors when configuring tests on iOS
- Disabled the BUILD_FLAG option in ios_test.sh script
- changed root's .gitignore file to disable only build* folders, not files

Resolves: OLPEDGE-428

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>