### PR TITLE
Detailed logs added to dataservice-read subsystem

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
@@ -20,8 +20,11 @@
 #include "ApiCacheRepository.h"
 
 #include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/logging/Log.h>
 
 namespace {
+constexpr char kACRLogtag[] = "ApiCacheRepository";
+
 std::string CreateKey(const std::string& hrn, const std::string& service,
                       const std::string& serviceVersion) {
   return hrn + "::" + service + "::" + serviceVersion + "::api";
@@ -41,6 +44,8 @@ void ApiCacheRepository::Put(const std::string& service,
                              const std::string& serviceVersion,
                              const std::string& serviceUrl) {
   std::string hrn(hrn_.ToCatalogHRNString());
+  auto key = CreateKey(hrn, service, serviceVersion);
+  LOG_TRACE_F(kACRLogtag, "Put '%s'", key.c_str());
   cache_->Put(CreateKey(hrn, service, serviceVersion), serviceUrl,
               [serviceUrl]() { return serviceUrl; }, 3600);
 }
@@ -48,8 +53,9 @@ void ApiCacheRepository::Put(const std::string& service,
 boost::optional<std::string> ApiCacheRepository::Get(
     const std::string& service, const std::string& serviceVersion) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  auto url = cache_->Get(CreateKey(hrn, service, serviceVersion),
-                         [](const std::string& value) { return value; });
+  auto key = CreateKey(hrn, service, serviceVersion);
+  LOG_TRACE_F(kACRLogtag, "Get '%s'", key.c_str());
+  auto url = cache_->Get(key, [](const std::string& value) { return value; });
   if (url.empty()) {
     return boost::none;
   }

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.cpp
@@ -28,7 +28,9 @@ namespace dataservice {
 namespace read {
 namespace repository {
 
-#define LOGTAG "ApiRepository"
+namespace {
+constexpr char kARLogtag[] = "ApiRepository";
+}
 
 using namespace olp::client;
 
@@ -49,13 +51,13 @@ ApiRepository::ApiRepository(
 olp::client::CancellationToken ApiRepository::getApiClient(
     const std::string& service, const std::string& serviceVersion,
     const ApiClientCallback& callback) {
-  LOG_TRACE_F(LOGTAG, "getApiClient(%s, %s)", service.c_str(),
+  LOG_TRACE_F(kARLogtag, "getApiClient(%s, %s)", service.c_str(),
               serviceVersion.c_str());
 
   auto url = cache_->Get(service, serviceVersion);
   if (url) {
-    LOG_TRACE_F(LOGTAG, "getApiClient(%s, %s) -> from cache", service.c_str(),
-                serviceVersion.c_str());
+    LOG_TRACE_F(kARLogtag, "getApiClient(%s, %s) -> from cache",
+                service.c_str(), serviceVersion.c_str());
 
     auto client = olp::client::OlpClientFactory::Create(*settings_);
     client->SetBaseUrl(*url);
@@ -69,14 +71,14 @@ olp::client::CancellationToken ApiRepository::getApiClient(
   MultiRequestContext<ApiClientResponse, ApiClientCallback>::ExecuteFn
       executeFn = [cache, hrn, settings, service,
                    serviceVersion](ApiClientCallback contextCallback) {
-        LOG_TRACE_F(LOGTAG, "getApiClient(%s, %s) -> execute", service.c_str(),
-                    serviceVersion.c_str());
+        LOG_TRACE_F(kARLogtag, "getApiClient(%s, %s) -> execute",
+                    service.c_str(), serviceVersion.c_str());
 
         auto cacheApiResponseCallback =
             [cache, hrn, settings, service, serviceVersion,
              contextCallback](ApiClientResponse response) {
               if (response.IsSuccessful()) {
-                LOG_TRACE_F(LOGTAG, "getApiClient(%s, %s) -> into cache",
+                LOG_TRACE_F(kARLogtag, "getApiClient(%s, %s) -> into cache",
                             service.c_str(), serviceVersion.c_str());
                 cache->Put(service, serviceVersion,
                            response.GetResult().GetBaseUrl());

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
@@ -22,6 +22,8 @@
 #include <string>
 
 #include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/logging/Log.h>
+
 // clang-format off
 #include "generated/parser/CatalogParser.h"
 #include "generated/parser/VersionResponseParser.h"
@@ -32,6 +34,8 @@
 // clang-format on
 
 namespace {
+constexpr char kCCRLogtag[] = "CatalogCacheRepository";
+
 std::string CreateKey(const std::string& hrn) { return hrn + "::catalog"; }
 std::string VersionKey(const std::string& hrn) {
   return hrn + "::latestVersion";
@@ -49,14 +53,18 @@ CatalogCacheRepository::CatalogCacheRepository(
 
 void CatalogCacheRepository::Put(const model::Catalog& catalog) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  cache_->Put(CreateKey(hrn), catalog,
+  auto key = CreateKey(hrn);
+  LOG_TRACE_F(kCCRLogtag, "Put '%s'", key.c_str());
+  cache_->Put(key, catalog,
               [catalog]() { return olp::serializer::serialize(catalog); });
 }
 
 boost::optional<model::Catalog> CatalogCacheRepository::Get() {
   std::string hrn(hrn_.ToCatalogHRNString());
+  auto key = CreateKey(hrn);
+  LOG_TRACE_F(kCCRLogtag, "Get '%s'", key.c_str());
   auto cachedCatalog =
-      cache_->Get(CreateKey(hrn), [](const std::string& serializedObject) {
+      cache_->Get(key, [](const std::string& serializedObject) {
         return parser::parse<model::Catalog>(serializedObject);
       });
   if (cachedCatalog.empty()) {
@@ -74,8 +82,10 @@ void CatalogCacheRepository::PutVersion(const model::VersionResponse& version) {
 
 boost::optional<model::VersionResponse> CatalogCacheRepository::GetVersion() {
   std::string hrn(hrn_.ToCatalogHRNString());
+  auto key = VersionKey(hrn);
+  LOG_TRACE_F(kCCRLogtag, "GetVersion '%s'", key.c_str());
   auto cachedVersion =
-      cache_->Get(VersionKey(hrn), [](const std::string& serializedObject) {
+      cache_->Get(key, [](const std::string& serializedObject) {
         return parser::parse<model::VersionResponse>(serializedObject);
       });
   if (cachedVersion.empty()) {
@@ -86,6 +96,8 @@ boost::optional<model::VersionResponse> CatalogCacheRepository::GetVersion() {
 
 void CatalogCacheRepository::Clear() {
   std::string hrn(hrn_.ToCatalogHRNString());
+
+  LOG_TRACE_F(kCCRLogtag, "GetVersion '%s'", CreateKey(hrn).c_str());
 
   cache_->RemoveKeysWithPrefix(hrn);
 }

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -20,8 +20,11 @@
 #include "DataCacheRepository.h"
 
 #include <olp/core/cache/KeyValueCache.h>
+#include <olp/core/logging/Log.h>
 
 namespace {
+constexpr char kDCRLogtag[] = "DataCacheRepository";
+
 std::string CreateKey(const std::string& hrn, const std::string& layer_id,
                       const std::string& datahandle) {
   return hrn + "::" + layer_id + "::" + datahandle + "::Data";
@@ -41,24 +44,30 @@ void DataCacheRepository::Put(const model::Data& data,
                               const std::string& layer_id,
                               const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  cache_->Put(CreateKey(hrn, layer_id, data_handle), data);
+  auto key = CreateKey(hrn, layer_id, data_handle);
+  LOG_TRACE_F(kDCRLogtag, "Put '%s'", key.c_str());
+  cache_->Put(key, data);
 }
 
 boost::optional<model::Data> DataCacheRepository::Get(
     const std::string& layer_id, const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  auto cachedData = cache_->Get(CreateKey(hrn, layer_id, data_handle));
+  auto key = CreateKey(hrn, layer_id, data_handle);
+  LOG_TRACE_F(kDCRLogtag, "Get '%s'", key.c_str());
+  auto cachedData = cache_->Get(key);
   if (!cachedData) {
     return boost::none;
   }
 
-  return cachedData;
+  return std::move(cachedData);
 }
 
-void DataCacheRepository::Clear(const std::string& layer_id, const std::string& data_handle) {
+void DataCacheRepository::Clear(const std::string& layer_id,
+                                const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
-
-  cache_->RemoveKeysWithPrefix(CreateKey(hrn, layer_id, data_handle));
+  auto key = CreateKey(hrn, layer_id, data_handle);
+  LOG_TRACE_F(kDCRLogtag, "Clear '%s'", key.c_str());
+  cache_->RemoveKeysWithPrefix(key);
 }
 
 }  // namespace repository


### PR DESCRIPTION
ApiCacheRepository, CatalogCacheRepository, CatalogRepository,
CatalogRepository, CatalogCacheRepository, DataRepository,
PartitionsCacheRepositorynow, DataRepository, PartitionsRepository
trace all their major steps.

Resolves: OLPEDGE-528

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>