### PR TITLE
Applies pimpl idiom with shared_ptr to CancellationContext.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -60,6 +60,7 @@ file(GLOB CACHE_HEADERS
 
 file(GLOB CLIENT_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/client/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/client/*.inl"
 )
 
 file(GLOB GENERATED_MODEL_HEADERS
@@ -296,6 +297,7 @@ export_config()
 
 if(EDGE_SDK_ENABLE_TESTING)
     add_subdirectory(tests/cache)
+    add_subdirectory(tests/client)
     add_subdirectory(tests/olpclient)
     add_subdirectory(tests/geo)
     add_subdirectory(tests/network)

--- a/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.inl
+++ b/olp-cpp-sdk-core/include/olp/core/client/CancellationContext.inl
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+namespace olp {
+namespace client {
+
+inline CancellationContext::CancellationContext()
+    : impl_(std::make_shared<CancellationContextImpl>()) {}
+
+inline void CancellationContext::ExecuteOrCancelled(
+    const std::function<CancellationToken()>& execute_fn,
+    const std::function<void()>& cancel_fn) {
+  if (!impl_) {
+    return;
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(impl_->mutex_);
+
+  if (impl_->is_cancelled_ && cancel_fn) {
+    cancel_fn();
+    return;
+  }
+
+  if (execute_fn) {
+    impl_->sub_operation_cancel_token_ = execute_fn();
+  }
+}
+
+inline void CancellationContext::CancelOperation() {
+  if (!impl_) {
+    return;
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(impl_->mutex_);
+  if (impl_->is_cancelled_) {
+    return;
+  }
+
+  impl_->sub_operation_cancel_token_.cancel();
+  impl_->sub_operation_cancel_token_ = CancellationToken();
+  impl_->is_cancelled_ = true;
+}
+
+inline bool CancellationContext::IsCancelled() const {
+  if (!impl_) {
+    return false;
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(impl_->mutex_);
+  return impl_->is_cancelled_;
+}
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/client/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/client/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Copyright (C) 2019 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+file(GLOB_RECURSE EDGE_SDK_SOURCES "unittest/*.cpp" "unittest/*.h")
+
+set(EDGE_SDK_TARGET client)
+
+if (ANDROID OR IOS)
+    add_library(${EDGE_SDK_TARGET}-test ${EDGE_SDK_SOURCES})
+else()
+    add_executable(${EDGE_SDK_TARGET}-test ${EDGE_SDK_SOURCES})
+endif()
+
+target_include_directories(${EDGE_SDK_TARGET}-test
+    PRIVATE ${PROJECT_SOURCE_DIR}/tests
+)
+
+target_link_libraries(${EDGE_SDK_TARGET}-test
+   olp-cpp-sdk-core
+)
+
+if (ANDROID)
+    # Create Android test runner app
+    target_link_libraries(${EDGE_SDK_TARGET}-test gtest gmock)
+
+    include(${CMAKE_SOURCE_DIR}/cmake/android/gen_android_test.cmake)
+    gen_android_test_runner(${EDGE_SDK_TARGET} ${EDGE_SDK_TARGET}-test)
+
+    add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/android ${CMAKE_CURRENT_BINARY_DIR}/android)
+elseif (IOS)
+    # Create iOS test runner app
+    target_link_libraries(${EDGE_SDK_TARGET}-test gtest gmock)
+
+    include(${CMAKE_SOURCE_DIR}/cmake/ios/gen_ios_test.cmake)
+    gen_ios_test_runner(${EDGE_SDK_TARGET} ${EDGE_SDK_TARGET}-test)
+
+    add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/ios ${CMAKE_CURRENT_BINARY_DIR}/ios)
+else()
+    target_link_libraries(${EDGE_SDK_TARGET}-test gtest_main gmock_main)
+endif()
+

--- a/olp-cpp-sdk-core/tests/client/unittest/CancellationContextTest.cpp
+++ b/olp-cpp-sdk-core/tests/client/unittest/CancellationContextTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gtest/gtest.h>
+
+#include <olp/core/client/CancellationContext.h>
+
+using olp::client::CancellationContext;
+
+TEST(CancellationContextTest, cancel_operation) {
+  CancellationContext context;
+
+  EXPECT_FALSE(context.IsCancelled());
+  context.CancelOperation();
+  EXPECT_TRUE(context.IsCancelled());
+}
+
+TEST(CancellationContextTest, copy_and_cancel_operation) {
+  CancellationContext context;
+  CancellationContext context_copy = context;
+
+  EXPECT_FALSE(context.IsCancelled());
+  EXPECT_FALSE(context_copy.IsCancelled());
+  context.CancelOperation();
+  EXPECT_TRUE(context.IsCancelled());
+  EXPECT_TRUE(context_copy.IsCancelled());
+}
+
+TEST(CancellationContextTest, move_and_cancel_operation) {
+  CancellationContext context;
+  CancellationContext context_move = std::move(context);
+
+  EXPECT_FALSE(context.IsCancelled());
+  EXPECT_FALSE(context_move.IsCancelled());
+  context_move.CancelOperation();
+  EXPECT_FALSE(context.IsCancelled());
+  EXPECT_TRUE(context_move.IsCancelled());
+}

--- a/scripts/linux_build.sh
+++ b/scripts/linux_build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash -xe
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -EDGE_SDK_BUILD_EXAMPLES=ON ..
+make -j8
+cd ..
 CPP_TEST_SOURCE_AUTHENTICATION=build/olp-cpp-sdk-authentication/test
 CPP_TEST_SOURCE_CORE=build/olp-cpp-sdk-core/tests
 echo ">>> Authentication Test ... >>>"


### PR DESCRIPTION
Currently to be able to share the CancellationContext accross multiple contexts
you need to wrap it inside a shared_ptr. As this is designed to be used accross
multiple contexts only, applying a pimpl idiom with shared_ptr automatically
takes care of sharing the CancellationContext.

Relates-to: OLPEDGE-402

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>