### PR TITLE
Build EdgeNetworkProtocol.jar with olp-cpp-sdk-core for Android

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -240,6 +240,9 @@ if(IOS)
     else()
         target_compile_options(${PROJECT_NAME} PRIVATE "-fobjc-arc")
     endif()
+elseif(ANDROID)
+    # Make sure that EdgeNetworkProtocol.jar is built before olp-cpp-sdk-core
+    add_dependencies(${PROJECT_NAME} ${EDGE_NETWORK_PROTOCOL_JAR})
 endif()
 
 if(CURL_FOUND)


### PR DESCRIPTION
Added dependency of olp-cpp-sdk-core on EdgeNetworkProtocol.jar in order to make sure that it is build always when building separate OLP targets

Resolves: OLPSUP-6840

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>