### PR TITLE
CatalogClientImpl logging improvement

### DIFF
--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogRequest.h
@@ -22,8 +22,11 @@
 #include "FetchOptions.h"
 
 #include <string>
+#include <sstream>
 
 #include <boost/optional.hpp>
+
+#include "DataServiceReadApi.h"
 
 namespace olp {
 namespace dataservice {
@@ -33,7 +36,7 @@ namespace read {
  * @brief The CatalogRequest class encapsulates the fields required to request
  * the Catalog configuration.
  */
-class CatalogRequest final {
+class DATASERVICE_READ_API CatalogRequest final {
  public:
   /**
    * @brief BillingTag is an optional free-form tag which is used for
@@ -88,7 +91,25 @@ class CatalogRequest final {
     fetch_option_ = fetchoption;
     return *this;
   }
- private:
+
+  /**
+   * @brief Creates readable format for the request.
+   * @param none
+   * @return string representation of the request
+   */
+  inline std::string CreateKey() const {
+    std::stringstream out;
+
+    if (GetBillingTag()) {
+      out << "$" << GetBillingTag().get();
+    }
+
+    out << "^" << GetFetchOption();
+
+    return out.str();
+  }
+
+private:
   boost::optional<std::string> billing_tag_;
   FetchOptions fetch_option_ = OnlineIfNotFound;
 };

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogVersionRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/CatalogVersionRequest.h
@@ -21,6 +21,7 @@
 
 #include "FetchOptions.h"
 
+#include <sstream>
 #include <string>
 
 #include <boost/optional.hpp>
@@ -32,12 +33,11 @@ namespace dataservice {
 namespace read {
 
 /**
- * @brief The CatalogVersionRequest class encapsulates the fields required to request
- * the Catalog configuration.
+ * @brief The CatalogVersionRequest class encapsulates the fields required to
+ * request the Catalog configuration.
  */
 class DATASERVICE_READ_API CatalogVersionRequest final {
  public:
-
   /**
    * @brief Mandatory for versioned layers; the beginning of the range of
    * versions you want to get (exclusive). By convention -1 indicates the
@@ -45,9 +45,7 @@ class DATASERVICE_READ_API CatalogVersionRequest final {
    * the catalog version is 0.
    * @return the start version.
    */
-  inline int64_t GetStartVersion() const {
-    return start_version_;
-  }
+  inline int64_t GetStartVersion() const { return start_version_; }
 
   /**
    * @brief WithStartVersion sets the start version. See ::GetStartVersion() for
@@ -99,9 +97,7 @@ class DATASERVICE_READ_API CatalogVersionRequest final {
    * resource is not in the cache.
    * @return the fetchOption
    */
-  inline FetchOptions GetFetchOption() const {
-    return fetch_option_;
-  }
+  inline FetchOptions GetFetchOption() const { return fetch_option_; }
 
   /**
    * @brief WithFetchOption sets the fetch option. See ::GetFetchOption() for
@@ -113,6 +109,26 @@ class DATASERVICE_READ_API CatalogVersionRequest final {
     fetch_option_ = fetchoption;
     return *this;
   }
+
+  /**
+   * @brief Creates readable format for the request.
+   * @param none
+   * @return string representation of the request
+   */
+  inline std::string CreateKey() const {
+    std::stringstream out;
+
+    out << "@" << GetStartVersion();
+
+    if (GetBillingTag()) {
+      out << "$" << GetBillingTag().get();
+    }
+
+    out << "^" << GetFetchOption();
+
+    return out.str();
+  }
+
  private:
   int64_t start_version_{0};
   boost::optional<std::string> billing_tag_;

--- a/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
+++ b/olp-cpp-sdk-dataservice-read/include/olp/dataservice/read/PartitionsRequest.h
@@ -22,6 +22,7 @@
 #include "FetchOptions.h"
 
 #include <string>
+#include <sstream>
 
 #include <boost/optional.hpp>
 
@@ -137,7 +138,29 @@ class DATASERVICE_READ_API PartitionsRequest final {
     return *this;
   }
 
- private:
+  /**
+   * @brief Creates readable format for the request.
+   * @param none
+   * @return string representation of the request
+   */
+  std::string CreateKey() const {
+    std::stringstream out;
+    out << GetLayerId();
+
+    if (GetVersion()) {
+      out << "@" << GetVersion().get();
+    }
+
+    if (GetBillingTag()) {
+      out << "$" << GetBillingTag().get();
+    }
+
+    out << "^" << GetFetchOption();
+
+    return out.str();
+  }
+
+private:
   std::string layer_id_;
   boost::optional<int64_t> catalog_metadata_version_;
   boost::optional<std::string> billing_tag_;

--- a/olp-cpp-sdk-dataservice-read/src/MultiRequestContext.h
+++ b/olp-cpp-sdk-dataservice-read/src/MultiRequestContext.h
@@ -58,7 +58,8 @@ class MultiRequestContext final {
 
     while (!active_reqs_->empty()) {
       auto itr = active_reqs_->begin();
-      LOG_INFO_F(kMultiRequestContextLogTag, "~MultiRequestContext() -> cancelling id %s",
+      LOG_INFO_F(kMultiRequestContextLogTag,
+                 "~MultiRequestContext() -> cancelling id %s",
                  itr->first.c_str());
       itr->second->cancellation_token_.cancel();
     }
@@ -70,8 +71,9 @@ class MultiRequestContext final {
       Callback callback_fn) {
     boost::uuids::uuid request_id = uuid_gen_();
 
-    LOG_TRACE_F(kMultiRequestContextLogTag, "ExecuteOrAssociate(%s) -> request uuid = %s",
-                key.c_str(), boost::uuids::to_string(request_id).c_str());
+    LOG_TRACE_F(kMultiRequestContextLogTag,
+                "ExecuteOrAssociate(%s) -> request uuid = %s", key.c_str(),
+                boost::uuids::to_string(request_id).c_str());
 
     std::shared_ptr<RequestContext> newContext;
 
@@ -80,13 +82,14 @@ class MultiRequestContext final {
 
       auto itr = active_reqs_->find(key);
       if (itr != active_reqs_->end()) {
-        LOG_INFO_F(kMultiRequestContextLogTag, "ExecuteOrAssociate(%s) -> existing request key",
+        LOG_INFO_F(kMultiRequestContextLogTag,
+                   "ExecuteOrAssociate(%s) -> existing request key",
                    key.c_str());
 
         itr->second->callbacks_[request_id] = callback_fn;
       } else {
-        LOG_INFO_F(kMultiRequestContextLogTag, "ExecuteOrAssociate(%s) -> new request key",
-                   key.c_str());
+        LOG_INFO_F(kMultiRequestContextLogTag,
+                   "ExecuteOrAssociate(%s) -> new request key", key.c_str());
 
         newContext = std::make_shared<RequestContext>();
         newContext->callbacks_[request_id] = callback_fn;
@@ -102,8 +105,8 @@ class MultiRequestContext final {
         onRequestCompleted(mutex, reqs, response, key);
       };
 
-      LOG_INFO_F(kMultiRequestContextLogTag, "ExecuteOrAssociate(%s) -> execute request()",
-                 key.c_str());
+      LOG_INFO_F(kMultiRequestContextLogTag,
+                 "ExecuteOrAssociate(%s) -> execute request()", key.c_str());
 
       newContext->cancellation_token_ = execute_fn(callback);
     }
@@ -132,7 +135,8 @@ class MultiRequestContext final {
   static void onRequestCompleted(std::shared_ptr<std::recursive_mutex> mutex,
                                  ReqsPtr reqs, Response response,
                                  std::string key) {
-    LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCompleted(%s)", key.c_str());
+    LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCompleted(%s)",
+                key.c_str());
     RequestContextPtr context;
 
     {
@@ -146,8 +150,9 @@ class MultiRequestContext final {
     }  // release the lock, then invoke the callbacks.
 
     if (context) {
-      LOG_INFO_F(kMultiRequestContextLogTag, "onRequestCompleted(%s) -> callback count = %lu",
-                 key.c_str(), (unsigned long)context->callbacks_.size());
+      LOG_INFO_F(kMultiRequestContextLogTag,
+                 "onRequestCompleted(%s) -> callback count = %lu", key.c_str(),
+                 context->callbacks_.size());
 
       for (auto& callback : context->callbacks_) {
         callback.second(response);
@@ -159,7 +164,8 @@ class MultiRequestContext final {
                                  std::shared_ptr<std::recursive_mutex> mutex,
                                  ReqsPtr reqs, const std::string& key,
                                  const boost::uuids::uuid& request_id) {
-    LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCancelled(%s)", key.c_str());
+    LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCancelled(%s)",
+                key.c_str());
     RequestContextPtr context;
 
     {
@@ -173,7 +179,8 @@ class MultiRequestContext final {
     }  // release the lock, then invoke the callbacks.
 
     if (context) {
-      LOG_INFO_F(kMultiRequestContextLogTag, "onRequestCancelled(key=%s, id=%s)", key.c_str(),
+      LOG_INFO_F(kMultiRequestContextLogTag,
+                 "onRequestCancelled(key=%s, id=%s)", key.c_str(),
                  boost::uuids::to_string(request_id).c_str());
 
       // find the callback by request_id

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -39,32 +39,6 @@ using namespace olp::client;
 
 namespace {
 constexpr auto kLogTag = "CatalogRepository";
-
-std::string CreateKey(const CatalogRequest& request) {
-  std::stringstream ss;
-
-  if (request.GetBillingTag()) {
-    ss << "$" << request.GetBillingTag().get();
-  }
-
-  ss << "^" << request.GetFetchOption();
-
-  return ss.str();
-}
-
-std::string CreateKey(const CatalogVersionRequest& request) {
-  std::stringstream ss;
-
-  ss << "@" << request.GetStartVersion();
-
-  if (request.GetBillingTag()) {
-    ss << "$" << request.GetBillingTag().get();
-  }
-
-  ss << "^" << request.GetFetchOption();
-
-  return ss.str();
-}
 }  // namespace
 
 CatalogRepository::CatalogRepository(
@@ -85,7 +59,7 @@ CancellationToken CatalogRepository::getCatalog(
   auto cancel_context = std::make_shared<CancellationContext>();
   auto& cache = *cache_;
 
-  auto requestKey = CreateKey(request);
+  auto requestKey = request.CreateKey();
   LOG_TRACE_F(kLogTag, "getCatalog '%s'", requestKey.c_str());
 
   MultiRequestContext<read::CatalogResponse,
@@ -184,7 +158,7 @@ CancellationToken CatalogRepository::getLatestCatalogVersion(
   auto cancel_context = std::make_shared<CancellationContext>();
   auto& cache = *cache_;
 
-  auto requestKey = CreateKey(request);
+  auto requestKey = request.CreateKey();
   LOG_TRACE_F(kLogTag, "getCatalogVersion '%s'", requestKey.c_str());
 
   cancel_context->ExecuteOrCancelled(


### PR DESCRIPTION
PartitionsRequest, CatalogRequest and CatalogVersionRequest now can
generate readable keys by themselves.
CatalogClientImpl class now logs all its major steps.

Relates-to: OLPEDGE-547

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>