### PR TITLE
Configure Travis CI for Android & IOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+    
 language: cpp
 os: linux
 dist: xenial
@@ -10,14 +11,35 @@ addons:
     - libcurl4-openssl-dev 
     - libboost-all-dev
     - clang
-script: $WORKSPACE/scripts/linux/build.sh && $WORKSPACE/scripts/linux/test.sh
 matrix:
   include:
   - compiler: clang
-  - compiler: gcc
-  - os: osx
+    name: Linux Build using clang & tests
     script: $WORKSPACE/scripts/linux/build.sh
+  - compiler: gcc
+    name: Linux Build using gcc & tests
+    script: $WORKSPACE/scripts/linux/build.sh && $WORKSPACE/scripts/linux/test.sh
+  - language: android
+    name: Android Build
+    os : linux
+    dist: xenial
+    language: cpp
+    before_script:
+    - wget https://dl.google.com/android/repository/android-ndk-r19c-linux-x86_64.zip
+    - wget https://dl.google.com/android/repository/android-21_r01.zip
+    - unzip -qq android-ndk-r19c-linux-x86_64.zip
+    - unzip -qq android-21_r01.zip
+    - export ANDROID_SDK_ROOT="$TRAVIS_BUILD_DIR/android-5.0"
+    - export ANDROID_NDK_HOME="$TRAVIS_BUILD_DIR/android-ndk-r19c"
+    script: $WORKSPACE/scripts/android/build.sh
+  - os: osx
+    name: OSX Build
+    script: $WORKSPACE/scripts/linux/build.sh
+  - os: osx
+    name: IOS Build
+    script: $WORKSPACE/scripts/ios/build.sh  
   - os: windows
+    name: Windows Build
     env: BUILD_TYPE=RelWithDebInfo WORKSPACE=$TRAVIS_BUILD_DIR
     script: $WORKSPACE/scripts/windows/build.sh
 branches:

--- a/scripts/android/build.sh
+++ b/scripts/android/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mv android-5.0 android-5.0_source && mkdir -p android-5.0/platforms/android-21 && cp -r android-5.0_source/* android-5.0/platforms/android-21/ && rm -rf android-5.0_source
+mkdir -p build && cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE="$WORKSPACE/android-ndk-r19c/build/cmake/android.toolchain.cmake" -DANDROID_ABI=arm64-v8a -DEDGE_SDK_ENABLE_TESTING=NO
+make

--- a/scripts/ios/build.sh
+++ b/scripts/ios/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mkdir -p build && cd build
+cmake ../ -GXcode -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/iOS.cmake -DPLATFORM=iphoneos -DEDGE_SDK_ENABLE_TESTING=NO -DSIMULATOR=YES
+xcodebuild
+cd ..


### PR DESCRIPTION
This will setup Travis CI to run Android build and IOS build in each job.
Add names labels to jobs.
Resolves: OLPEDGE-531

Signed-off-by: Oleksandr Rudenko <ext-oleksandr.rudenko@here.com>