### PR TITLE
Remove specialized methods from logging::Configuration class.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/logging/Configuration.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Configuration.h
@@ -65,36 +65,17 @@ class CORE_API Configuration {
   using AppenderList = std::vector<AppenderWithLogLevel>;
 
   /**
-   * @brief Creates a default configuration.
+   * @brief Creates a default configuration by adding the DebugAppender and the
+   * ConsoleAppender as appenders.
    * @return The default configuration.
    */
   static Configuration createDefault();
-
-  inline Configuration();
-  Configuration(const Configuration&) = default;
-  Configuration& operator=(const Configuration&) = default;
-  inline Configuration(Configuration&& other) noexcept;
-  inline Configuration& operator=(Configuration&& other) noexcept;
 
   /**
    * @brief Returns whether or not the configuration is valid.
    * @return Whether or not the configuration is valid.
    */
   inline bool isValid() const;
-
-  /**
-   * @brief Adds the console appender to the configuration. Log level of the
-   * added appender is set to logging::Level::Trace.
-   * @param formatter The message formatter.
-   */
-  Configuration& addConsoleAppender(
-      MessageFormatter formatter = MessageFormatter::createDefault());
-
-  /**
-   * @brief Adds the debug appender (if applicable) to the configuration. Log
-   * level of the added appender is set to logging::Level::Trace.
-   */
-  Configuration& addDebugAppender();
 
   /**
    * @brief Adds an appender along with its logging level to the configuration.
@@ -120,22 +101,14 @@ class CORE_API Configuration {
   AppenderList m_appenders;
 };
 
-inline Configuration::Configuration() {}
-
-inline Configuration::Configuration(Configuration&& other) noexcept
-    : m_appenders(std::move(other.m_appenders)) {}
-
-inline Configuration& Configuration::operator=(Configuration&& other) noexcept {
-  m_appenders = std::move(other.m_appenders);
-  return *this;
-}
-
 inline bool Configuration::isValid() const { return !m_appenders.empty(); }
 
 inline Configuration& Configuration::addAppender(
     std::shared_ptr<IAppender> appender, logging::Level level) {
-  AppenderWithLogLevel appenderWithLogLevel = {level, std::move(appender)};
-  m_appenders.emplace_back(std::move(appenderWithLogLevel));
+  if (appender) {
+    AppenderWithLogLevel appenderWithLogLevel = {level, std::move(appender)};
+    m_appenders.emplace_back(std::move(appenderWithLogLevel));
+  }
   return *this;
 }
 

--- a/olp-cpp-sdk-core/src/logging/Configuration.cpp
+++ b/olp-cpp-sdk-core/src/logging/Configuration.cpp
@@ -17,32 +17,27 @@
  * License-Filename: LICENSE
  */
 
-#include <olp/core/logging/Configuration.h>
-#include <olp/core/logging/ConsoleAppender.h>
-#include <olp/core/logging/DebugAppender.h>
-#include <cstdlib>
-#include <fstream>
-#include <iostream>
+#include "olp/core/logging/Configuration.h"
+
 #include <memory>
+
+#include "olp/core/logging/ConsoleAppender.h"
+#include "olp/core/logging/DebugAppender.h"
 
 namespace olp {
 namespace logging {
+
 Configuration Configuration::createDefault() {
   Configuration configuration;
-  configuration.addConsoleAppender();
-  configuration.addDebugAppender();
+
+  configuration.addAppender(
+      std::make_shared<ConsoleAppender>(MessageFormatter::createDefault()));
+
+  if (DebugAppender::isImplemented()) {
+    configuration.addAppender(std::make_shared<DebugAppender>());
+  }
+
   return configuration;
-}
-
-Configuration& Configuration::addConsoleAppender(MessageFormatter formatter) {
-  addAppender(std::make_shared<ConsoleAppender>(std::move(formatter)));
-  return *this;
-}
-
-Configuration& Configuration::addDebugAppender() {
-  if (DebugAppender::isImplemented())
-    addAppender(std::make_shared<DebugAppender>());
-  return *this;
 }
 
 }  // namespace logging


### PR DESCRIPTION
This commit removes Configuration::addConsoleAppender() and
Configuration::addDebugAppender() as they are specialized methods which
can also be achieved trough addAppender().
Also applies rule of zero to Configuration class as default operations
are not needed if members have special functions defined.

Relates-to: OLPEDGE-406

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>