### PR TITLE
minor: return value adjustment of NetworkResponse

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/network2/NetworkResponse.h
+++ b/olp-cpp-sdk-core/include/olp/core/network2/NetworkResponse.h
@@ -78,7 +78,7 @@ class CORE_API NetworkResponse final {
    * @brief Get id of associated network request.
    * @return id of associated network request.
    */
-  const RequestId GetRequestId() const;
+   RequestId GetRequestId() const;
 
   /**
    * @brief Set id of associated network request.

--- a/olp-cpp-sdk-core/src/network2/NetworkResponse.cpp
+++ b/olp-cpp-sdk-core/src/network2/NetworkResponse.cpp
@@ -43,7 +43,7 @@ NetworkResponse& NetworkResponse::WithError(std::string error) {
   return *this;
 }
 
-const RequestId NetworkResponse::GetRequestId() const { return request_id_; }
+RequestId NetworkResponse::GetRequestId() const { return request_id_; }
 
 NetworkResponse& NetworkResponse::WithRequestId(RequestId id) {
   request_id_ = id;


### PR DESCRIPTION
NetworkResponse's GetRequestId() method now returns plain RequestId
instead of const, as constant qualifier has no effect on return value.

Relates-to: OLPEDGE-368

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>