### PR TITLE
Add ThreadPoolTaskScheduler implementing TaskScheduler class.

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -21,18 +21,15 @@ project(olp-cpp-sdk-core VERSION 0.6.0)
 set(DESCRIPTION "Core network and utility library for OLP C++ SDK")
 
 find_package(RapidJSON REQUIRED)
-
 find_package(Boost REQUIRED)
-
 find_package(leveldb REQUIRED)
 find_package(Snappy REQUIRED)
+find_package(Threads REQUIRED)
 
 include(configs/ConfigNetwork.cmake)
-
 include(cmake/CompileChecks.cmake)
-porting_do_checks()
 
-find_package(Threads REQUIRED)
+porting_do_checks()
 
 if(ANDROID OR IOS OR WIN32)
     set(NETWORK_NO_CURL ON)
@@ -235,6 +232,10 @@ if (ANDROID)
     set(ADDITIONAL_LIBRARIES log)
 else()
     set(ADDITIONAL_LIBRARIES)
+endif()
+
+if (HAVE_PTHREAD_SETNAME_NP)
+    add_definitions(-DEDGE_SDK_HAVE_PTHREAD_SETNAME_NP)
 endif()
 
 target_link_libraries(${PROJECT_NAME}

--- a/olp-cpp-sdk-core/cmake/CompileChecks.cmake
+++ b/olp-cpp-sdk-core/cmake/CompileChecks.cmake
@@ -22,12 +22,13 @@ function(porting_do_checks)
   endif()
 
   include(CheckCXXSourceCompiles)
-
   include(TestBigEndian)
+
   test_big_endian(PORTING_SYSTEM_BIG_ENDIAN)
 
-  # run the cxx compile test with c++xx flags
+  # run the cxx compile test with c++xx flags and pthreads library
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${CMAKE_CXX${CMAKE_CXX_STANDARD}_EXTENSION_COMPILE_OPTION}")
+  set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
   set(HAVE_STD_OPTIONAL OFF PARENT_SCOPE)
   check_cxx_source_compiles(
@@ -46,6 +47,13 @@ function(porting_do_checks)
     "#include <filesystem>
     int main() { return static_cast<int>(std::filesystem::file_type::directory); }"
     HAVE_STD_FILESYSTEM)
+
+  set(HAVE_PTHREAD_SETNAME_NP OFF PARENT_SCOPE)
+  check_cxx_source_compiles(
+    "#define _GNU_SOURCE 1
+    #include <pthread.h>
+    int main() { pthread_t thread; pthread_setname_np(thread, NULL); }"
+    HAVE_PTHREAD_SETNAME_NP)
 
   configure_file(${PATH_TO_INPUT_FILE}porting_config.h.in
     include/olp/core/porting/porting_config.h

--- a/olp-cpp-sdk-core/include/olp/core/thread/ThreadPoolTaskScheduler.h
+++ b/olp-cpp-sdk-core/include/olp/core/thread/ThreadPoolTaskScheduler.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <thread>
+#include <vector>
+
+#include <olp/core/thread/SyncQueue.h>
+#include <olp/core/thread/TaskScheduler.h>
+
+namespace olp {
+namespace thread {
+
+class CORE_API ThreadPoolTaskScheduler final : public TaskScheduler {
+ public:
+  /**
+   * @brief Constructor with default thread_count set to 1.
+   * @param[in] thread_count Number of threads to be initialized in the thread
+   * pool.
+   */
+  ThreadPoolTaskScheduler(size_t thread_count = 1u);
+
+  /**
+   * @brief Destructor that will close the SyncQueue and join threads.
+   */
+  ~ThreadPoolTaskScheduler() override;
+
+  // Non-copyable, non-movable
+  ThreadPoolTaskScheduler(const ThreadPoolTaskScheduler&) = delete;
+  ThreadPoolTaskScheduler& operator=(const ThreadPoolTaskScheduler&) = delete;
+  ThreadPoolTaskScheduler(ThreadPoolTaskScheduler&&) = delete;
+  ThreadPoolTaskScheduler& operator=(ThreadPoolTaskScheduler&&) = delete;
+
+ protected:
+  /// Override base class method to enqueue tasks and execute them eventually on
+  /// the next free thread from the thread pool.
+  void EnqueueTask(TaskScheduler::CallFuncType&& func) override;
+
+ private:
+  /// Thread pool created in constructor.
+  std::vector<std::thread> thread_pool_;
+  /// SyncQueue used to manage tasks.
+  SyncQueueFifo<TaskScheduler::CallFuncType> sync_queue_;
+};
+
+}  // namespace thread
+}  // namespace olp

--- a/olp-cpp-sdk-core/include/olp/core/utils/WarningWorkarounds.h
+++ b/olp-cpp-sdk-core/include/olp/core/utils/WarningWorkarounds.h
@@ -27,14 +27,14 @@
 /**
  * Marks arbitrary many variables as unused to avoid compiler warnings.
  */
-#define CORE_UNUSED(...) hf::core::unused(__VA_ARGS__)
+#define CORE_UNUSED(...) olp::core::Unused(__VA_ARGS__)
 
-namespace hf {
+namespace olp {
 namespace core {
 template <typename... Args>
-void unused(Args&&...) {}
+void Unused(Args&&...) {}
 }  // namespace core
-}  // namespace hf
+}  // namespace olp
 
 /**
  * While statement for "do {} while (0)" used for macros that bypasses compiler

--- a/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
+++ b/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "olp/core/thread/ThreadPoolTaskScheduler.h"
+
+#if defined(PORTING_PLATFORM_QNX)
+#include <process.h>
+#elif defined(PORTING_PLATFORM_MAC)
+#include <pthread.h>
+#elif defined(PORTING_PLATFORM_LINUX) || defined(PORTING_PLATFORM_ANDROID)
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#include <pthread.h>
+#endif
+#include <string>
+
+#include "olp/core/logging/Log.h"
+#include "olp/core/porting/platform.h"
+#include "olp/core/utils/WarningWorkarounds.h"
+
+namespace olp {
+namespace thread {
+
+namespace {
+constexpr auto kLogTag = "ThreadPoolTaskScheduler";
+
+void SetCurrentThreadName(const std::string& thread_name) {
+  // Currently only supported for pthread users
+
+#if defined(PORTING_PLATFORM_MAC)
+  // Note that in Mac based systems the pthread_setname_np takes 1 argument
+  // only.
+  pthread_setname_np(thread_name.c_str());
+#elif defined(PORTING_PLATFORM_WINDOWS) || defined(PORTING_PLATFORM_EMSCRIPTEN)
+  // Unused
+  CORE_UNUSED(thread_name);
+#else  // Linux, Android, QNX
+#if defined(EDGE_SDK_HAVE_PTHREAD_SETNAME_NP)
+  // QNX allows 100 but Linux only 16 so select min value and apply for both.
+  // If maximum length is exceeded on some systems, e.g. Linux, the name is not
+  // set at all. So better truncate it to have at least the minimum set.
+  constexpr size_t kMaxThreadNameLength = 16u;
+  std::string truncated_name = thread_name.substr(0, kMaxThreadNameLength - 1);
+  pthread_setname_np(pthread_self(), truncated_name.c_str());
+#endif  // EDGE_SDK_HAVE_PTHREAD_SETNAME_NP
+#endif  // PORTING_PLATFORM_MAC
+}
+
+}  // namespace
+
+ThreadPoolTaskScheduler::ThreadPoolTaskScheduler(size_t thread_count) {
+  thread_pool_.reserve(thread_count);
+
+  for (size_t idx = 0; idx < thread_count; ++idx) {
+    std::thread executor([this, idx]() {
+      // Set thread name for easy profiling and debugging
+      std::string thread_name = "OLPSDKPOOL_" + std::to_string(idx);
+      SetCurrentThreadName(thread_name);
+      LOG_INFO_F(kLogTag, "Starting thread '%s'", thread_name.c_str());
+
+      for (;;) {
+        TaskScheduler::CallFuncType task;
+        if (!sync_queue_.Pull(task)) return;
+        task();
+      }
+    });
+
+    thread_pool_.push_back(std::move(executor));
+  }
+}
+
+ThreadPoolTaskScheduler::~ThreadPoolTaskScheduler() {
+  sync_queue_.Close();
+  for (auto& thread : thread_pool_) {
+    thread.join();
+  }
+  thread_pool_.clear();
+}
+
+void ThreadPoolTaskScheduler::EnqueueTask(TaskScheduler::CallFuncType&& func) {
+  sync_queue_.Push(std::move(func));
+}
+
+}  // namespace thread
+}  // namespace olp

--- a/olp-cpp-sdk-core/tests/thread/unittest/ThreadPoolTaskSchedulerTest.cpp
+++ b/olp-cpp-sdk-core/tests/thread/unittest/ThreadPoolTaskSchedulerTest.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <olp/core/client/CancellationContext.h>
+#include <olp/core/thread/ThreadPoolTaskScheduler.h>
+
+using SyncTaskType = std::function<void()>;
+using CancellationContext = olp::client::CancellationContext;
+using TaskScheduler = olp::thread::TaskScheduler;
+using ThreadPool = olp::thread::ThreadPoolTaskScheduler;
+
+using namespace ::testing;
+using namespace std::chrono;
+
+namespace {
+constexpr size_t kThreads{3u};
+constexpr size_t kNumTasks{30u};
+constexpr milliseconds kSleep{100};
+constexpr int64_t kMaxWaitMs{1000};
+}  // namespace
+
+TEST(ThreadPoolTaskSchedulerTest, single_user_push) {
+  SCOPED_TRACE("Single user pushes tasks");
+
+  // Start thread pool
+  auto thread_pool = std::make_shared<ThreadPool>(kThreads);
+  TaskScheduler& scheduler = *thread_pool;
+  std::atomic<uint32_t> counter(0u);
+
+  // Allow threads to start
+  std::this_thread::sleep_for(kSleep);
+
+  // Add tasks to the queue, threads should start executing them
+  for (uint32_t idx = 0u; idx < kNumTasks; ++idx) {
+    scheduler.ScheduleTask([&](const CancellationContext&) { ++counter; });
+  }
+
+  // Wait for threads to finish but do not exceed 1min
+  const auto start = system_clock::now();
+  auto check_condition = [&]() {
+    return counter.load() < kNumTasks &&
+           duration_cast<milliseconds>(system_clock::now() - start).count() <
+               kMaxWaitMs;
+  };
+
+  while (check_condition()) {
+    std::this_thread::sleep_for(kSleep);
+  }
+
+  EXPECT_EQ(kNumTasks, counter.load());
+
+  // Close queue and join threads.
+  // SyncQueue and threads join should be done in destructor.
+  thread_pool.reset();
+}
+
+TEST(ThreadPoolTaskSchedulerTest, multi_user_push) {
+  SCOPED_TRACE("Multiple users push tasks");
+
+  constexpr uint32_t kPushThreads = 3;
+  constexpr uint32_t kTotalTasks = kPushThreads * kNumTasks;
+
+  // Start thread pool
+  auto thread_pool = std::make_shared<ThreadPool>(kThreads);
+  std::atomic<uint32_t> counter(0u);
+  std::vector<std::thread> push_threads;
+
+  // Allow threads to start
+  std::this_thread::sleep_for(kSleep);
+
+  // Create and start push threads for concurrent task creation
+  push_threads.reserve(kPushThreads);
+  for (size_t idx = 0; idx < kPushThreads; ++idx) {
+    push_threads.emplace_back([=, &counter] {
+      TaskScheduler& scheduler = *thread_pool;
+      for (uint32_t idx = 0u; idx < kNumTasks; ++idx) {
+        scheduler.ScheduleTask([&](const CancellationContext&) { ++counter; });
+        std::this_thread::sleep_for(kSleep / 100);
+      }
+    });
+  }
+
+  // Wait for threads to finish but do not exceed 1min
+  const auto start = system_clock::now();
+  auto check_condition = [&]() {
+    return counter.load() < kTotalTasks &&
+           duration_cast<milliseconds>(system_clock::now() - start).count() <
+               kMaxWaitMs;
+  };
+
+  while (check_condition()) {
+    std::this_thread::sleep_for(kSleep);
+  }
+
+  EXPECT_EQ(kTotalTasks, counter.load());
+
+  // Close queue and join threads.
+  // SyncQueue and threads join should be done in destructor.
+  thread_pool.reset();
+
+  for (auto& thread : push_threads) {
+    thread.join();
+  }
+  push_threads.clear();
+}


### PR DESCRIPTION
ThreadPoolTaskScheduler is an async task handler with user-defined amount of
concurrent threads listening to a SyncQueue that is fed by the user with
tasks to be executed trough the TaskScheduler API. Each thread started gets a distinct name, 
this way it is easier to profile or debug the thread pool in case of an error or in a complex system to track which component uses to much CPU time. Thread name setup is currently only supported for Linux, QNX and macOS.
Two basic unit tests scenarios with single-user push and multi-user push also added.

Relates-to: OLPEDGE-394

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>