### PR TITLE
Configure Travis CI for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-    
 language: cpp
 os: linux
 dist: xenial
@@ -14,10 +13,12 @@ addons:
 matrix:
   include:
   - compiler: clang
-    name: Linux Build using clang & tests
+    env: BUILD_TYPE=RelWithDebInfo WORKSPACE=$TRAVIS_BUILD_DIR
+    name: Linux Build using clang 
     script: $WORKSPACE/scripts/linux/build.sh
   - compiler: gcc
-    name: Linux Build using gcc & tests
+    env: BUILD_TYPE=COVERAGE WORKSPACE=$TRAVIS_BUILD_DIR
+    name: Linux Build using gcc & tests & code coverage
     script: $WORKSPACE/scripts/linux/build.sh && $WORKSPACE/scripts/linux/test.sh
   - language: android
     name: Android Build
@@ -33,15 +34,12 @@ matrix:
     - export ANDROID_NDK_HOME="$TRAVIS_BUILD_DIR/android-ndk-r19c"
     script: $WORKSPACE/scripts/android/build.sh
   - os: osx
+    env: BUILD_TYPE=RelWithDebInfo WORKSPACE=$TRAVIS_BUILD_DIR
     name: OSX Build
     script: $WORKSPACE/scripts/linux/build.sh
   - os: osx
     name: IOS Build
     script: $WORKSPACE/scripts/ios/build.sh  
-  - os: windows
-    name: Windows Build
-    env: BUILD_TYPE=RelWithDebInfo WORKSPACE=$TRAVIS_BUILD_DIR
-    script: $WORKSPACE/scripts/windows/build.sh
 branches:
   only:
   - master

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
-[![Build Status](https://travis-ci.com/heremaps/here-olp-edge-sdk-cpp.svg?branch=master)](https://travis-ci.com/heremaps/here-olp-edge-sdk-cpp)
-[![Build Status](https://dev.azure.com/heremaps/github/_apis/build/status/heremaps.here-olp-edge-sdk-cpp?branchName=master)](https://dev.azure.com/heremaps/github/_build/latest?definitionId=1&branchName=master)
-
 # HERE OLP Edge SDK C++
 
 The HERE OLP Edge SDK is a _work in progress_ c++ client for [HERE Open Location Platform](https://platform.here.com).
+
+&nbsp;
+
+| Linux                          | Windows                         |
+| :----------------------------- | :------------------------------ |
+| [![Linux build status][1]][2]  | [![Windows build status][3]][4] |
+| [![Linux code coverage][4]][5] |                                 |
+
+
+[1]: https://travis-ci.com/heremaps/here-olp-edge-sdk-cpp.svg?branch=master
+[2]: https://travis-ci.com/heremaps/here-olp-edge-sdk-cpp
+[3]: https://dev.azure.com/heremaps/github/_apis/build/status/heremaps.here-olp-edge-sdk-cpp?branchName=master
+[4]: https://dev.azure.com/heremaps/github/_build/latest?definitionId=1&branchName=master
+[5]: https://codecov.io/gh/heremaps/here-olp-edge-sdk-cpp/branch/master/graph/badge.svg
+[6]: https://codecov.io/gh/heremaps/here-olp-edge-sdk-cpp/
 
 ## Why Use the SDK
 

--- a/scripts/linux/build.sh
+++ b/scripts/linux/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -EDGE_SDK_BUILD_EXAMPLES=ON ..
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -EDGE_SDK_BUILD_EXAMPLES=ON ..
 make -j8
 cd ..

--- a/scripts/linux/test.sh
+++ b/scripts/linux/test.sh
@@ -13,3 +13,4 @@ echo ">>> Core - Network Test ... >>>"
 $CPP_TEST_SOURCE_CORE/network/olp-core-network-test --gtest_output="xml:report4.xml" --gtest_filter="*Offline*:*offline*"
 echo ">>> Core - Thread Test ... >>>"
 $CPP_TEST_SOURCE_CORE/thread/thread-test --gtest_output="xml:report5.xml"
+bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This will setup Travis CI to run code coverage on gcc compiler job.
Add badges to README.md file.
Remove windows build from Travis CI because of Azure pipelines.
Resolves: OLPEDGE-238

Signed-off-by: Oleksandr Rudenko <ext-oleksandr.rudenko@here.com>