### PR TITLE
General LOGGING_DISABLED macro prefix adjustment

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/logging/Log.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Log.h
@@ -64,8 +64,8 @@
 /**
  * @brief Log a message using C++ style streams.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param level Logging level.
  * @param tag Log component name.
@@ -84,8 +84,8 @@
 /**
  * @brief Log a critical message using C++ style streams.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param level Logging level.
  * @param tag Log component name.
@@ -97,8 +97,8 @@
 /**
  * @brief Log a critical info message using C++ style streams.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param tag Log component name.
  * @param message The message to log.
@@ -109,8 +109,8 @@
 /**
  * @brief Log a critical warning message using C++ style streams.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param tag Log component name.
  * @param message The message to log.
@@ -121,8 +121,8 @@
 /**
  * @brief Log a critical error message using C++ style streams.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param tag Log component name.
  * @param message The message to log.
@@ -133,8 +133,8 @@
 /**
  * @brief Log a fatal error message using C++ style streams.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param tag Log component name.
  * @param message The message to log.
@@ -158,8 +158,8 @@
 /**
  * @brief Log a message using printf style formatting.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param level Logging level.
  * @param tag Log component name.
@@ -175,8 +175,8 @@
 /**
  * @brief Log a critical message using printf style formatting.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param level Logging level.
  * @param tag Log component name.
@@ -187,8 +187,8 @@
 /**
  * @brief Log a critical info message using printf style formatting.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param tag Log component name.
  */
@@ -198,8 +198,8 @@
 /**
  * @brief Log a critical warning message using printf style formatting.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param tag Log component name.
  */
@@ -209,8 +209,8 @@
 /**
  * @brief Log a critical error message using printf style formatting.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param tag Log component name.
  */
@@ -220,8 +220,8 @@
 /**
  * @brief Log a critical fatal error message using printf style formatting.
  *
- * LOGGING_DISABLED does not disable this functionality. Additionally, this will
- * not check to see if the tag is disabled.
+ * EDGE_SDK_LOGGING_DISABLED does not disable this functionality. Additionally,
+ * this will not check to see if the tag is disabled.
  *
  * @param tag Log component name.
  */
@@ -240,7 +240,7 @@
   }                                         \
   EDGE_SDK_CORE_LOOP_ONCE()
 
-#ifdef LOGGING_DISABLED
+#ifdef EDGE_SDK_LOGGING_DISABLED
 #define EDGE_SDK_LOG(level, tag, message) \
   do {                                    \
   }                                       \
@@ -261,7 +261,7 @@
   }                                                   \
   EDGE_SDK_CORE_LOOP_ONCE()
 
-#endif  // LOGGING_DISABLED
+#endif  // EDGE_SDK_LOGGING_DISABLED
 
 #ifdef LOGGING_DISABLE_DEBUG_LEVEL
 #define LOG_TRACE(tag, message)           \
@@ -323,7 +323,7 @@
 #define LOG_ERROR(tag, message) \
   EDGE_SDK_LOG(::olp::logging::Level::Error, tag, message)
 
-#ifdef LOGGING_DISABLED
+#ifdef EDGE_SDK_LOGGING_DISABLED
 #define EDGE_SDK_LOG_F(level, tag, ...) \
   do {                                  \
   }                                     \
@@ -342,7 +342,7 @@
   }                                                   \
   EDGE_SDK_CORE_LOOP_ONCE()
 
-#endif  // LOGGING_DISABLED
+#endif  // EDGE_SDK_LOGGING_DISABLED
 
 #ifdef LOGGING_DISABLE_DEBUG_LEVEL
 #define LOG_TRACE_F(tag, ...) CORE_UNUSED(tag, __VA_ARGS__)

--- a/olp-cpp-sdk-core/src/network/Network.cpp
+++ b/olp-cpp-sdk-core/src/network/Network.cpp
@@ -375,7 +375,7 @@ Network::RequestId Network::Send(NetworkRequest request,
 
   LOG_TRACE(LOGTAG,
             "send " << olp::utils::CensorCredentialsInUrl(request.Url()));
-#if !defined(LOGGING_DISABLED)
+#if !defined(EDGE_SDK_LOGGING_DISABLED)
   for (const auto& header : request.ExtraHeaders()) {
     LOG_TRACE(LOGTAG,
               "extra header: " << header.first << ": " << header.second);

--- a/olp-cpp-sdk-core/src/network/RequestContext.h
+++ b/olp-cpp-sdk-core/src/network/RequestContext.h
@@ -50,14 +50,14 @@ struct RequestContext {
 
   /// Destructor
   ~RequestContext() {
-#if defined(LOGGING_DISABLED)
+#if defined(EDGE_SDK_LOGGING_DISABLED)
     using namespace std::chrono;
     const auto life_time =
         duration_cast<seconds>(steady_clock::now() - creation_time_).count();
 
     LOG_TRACE("RequestContext",
-              ("Destroying context for request " + porting::to_string(id_) +
-               " after " + porting::to_string(life_time) + " sec.")
+              ("Destroying context for request " + std::to_string(id_) +
+               " after " + std::to_string(life_time) + " sec.")
                   .c_str());
 #endif
   }

--- a/olp-cpp-sdk-core/src/network/ios/HttpTask.mm
+++ b/olp-cpp-sdk-core/src/network/ios/HttpTask.mm
@@ -91,14 +91,14 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
     request.HTTPBody = self.body;
   }
 
-#ifndef LOGGING_DISABLED
+#ifndef EDGE_SDK_LOGGING_DISABLED
   NSMutableString* debugHeaders = [NSMutableString new];
 #endif
 
   for (NSString* key in self.headers.allKeys) {
     NSString* value = self.headers[key];
     [request setValue:value forHTTPHeaderField:key];
-#ifndef LOGGING_DISABLED
+#ifndef EDGE_SDK_LOGGING_DISABLED
     [debugHeaders appendFormat:@"%@\"%@:%@\"", @" --header ", key, value];
 #endif
   }
@@ -111,7 +111,7 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
   // Cache the task id for fast retrieve later on
   _httpClient.idTaskMap[@(self.dataTask.taskIdentifier)] = self;
 
-#ifndef LOGGING_DISABLED
+#ifndef EDGE_SDK_LOGGING_DISABLED
   NSMutableString* debugCurlString = [NSMutableString stringWithString:@"curl -vvv "];
   [debugCurlString appendFormat:@"\"%@\"%@", _requestUrl, debugHeaders];
   LOG_TRACE(LOGTAG, "HttpTask::run [ " << (__bridge void*)self << " ] "
@@ -162,7 +162,7 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
 }
 
 - (void)didReceiveResponse:(NSURLResponse*)response {
-#ifndef LOGGING_DISABLED
+#ifndef EDGE_SDK_LOGGING_DISABLED
   NSInteger httpResponseStatusCode = [(NSHTTPURLResponse*)response statusCode];
   LOG_TRACE(LOGTAG, "HttpTask::didReceiveResponse [ " << (__bridge void*)self << " ] "
                                                       << self.dataTask.taskIdentifier << "\t"


### PR DESCRIPTION
The macro-enabler is now called EDGE_SDK_LOGGING_DISABLED

Relates-to: OLPEDGE-407

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>