### PR TITLE
Logging prefix for 'core' subproject

### DIFF
--- a/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
+++ b/olp-cpp-sdk-core/src/cache/DefaultCache.cpp
@@ -102,8 +102,8 @@ bool DefaultCache::Clear() {
     }
   }
   if (SetupStorage() != DefaultCache::StorageOpenResult::Success) {
-    LOG_DEBUG_F(LOGTAG, "Failed to reopen the diskcache %s",
-                settings_.disk_path.get().c_str());
+    EDGE_SDK_LOG_DEBUG_F(LOGTAG, "Failed to reopen the diskcache %s",
+                         settings_.disk_path.get().c_str());
     return false;
   }
   return true;

--- a/olp-cpp-sdk-core/src/network/NetworkFactory.cpp
+++ b/olp-cpp-sdk-core/src/network/NetworkFactory.cpp
@@ -47,7 +47,8 @@ std::shared_ptr<NetworkProtocol> NetworkFactory::CreateNetworkProtocol() {
       g_default_network_protocol_factory =
           std::make_shared<DefaultNetworkProtocolFactory>();
     }
-    LOG_INFO(LOGTAG, "createNetworkProtocol: using default protocol factory");
+    EDGE_SDK_LOG_INFO(LOGTAG,
+                      "createNetworkProtocol: using default protocol factory");
     factory = g_default_network_protocol_factory;
   }
 

--- a/olp-cpp-sdk-core/src/network/NetworkSystemConfig.cpp
+++ b/olp-cpp-sdk-core/src/network/NetworkSystemConfig.cpp
@@ -27,8 +27,7 @@ namespace olp {
 namespace network {
 NetworkSystemConfig::NetworkSystemConfig(const NetworkProxy& system_proxy,
                                          const std::string& certificate_path)
-    : certificate_path_(certificate_path),
-      proxy_(system_proxy) {}
+    : certificate_path_(certificate_path), proxy_(system_proxy) {}
 
 void NetworkSystemConfig::SetProxy(const NetworkProxy& proxy) {
   proxy_ = proxy;
@@ -58,8 +57,8 @@ bool NetworkSystemConfig::DontVerifyCertificate() const {
   // Allow overriding of Certificate verification for
   //  troubleshooting/development purposes
   if (Settings::GetEnvInt("NETWORK_SSL_VERIFY", -1) == 0) {
-    LOG_INFO(LOGTAG,
-             "Network SSL verification disabled by NETWORK_SSL_VERIFY=0");
+    EDGE_SDK_LOG_INFO(
+        LOGTAG, "Network SSL verification disabled by NETWORK_SSL_VERIFY=0");
     return true;
   }
 #endif  // NETWORK_SSL_VERIFY_OVERRIDE

--- a/olp-cpp-sdk-core/src/network/RequestContext.h
+++ b/olp-cpp-sdk-core/src/network/RequestContext.h
@@ -55,10 +55,10 @@ struct RequestContext {
     const auto life_time =
         duration_cast<seconds>(steady_clock::now() - creation_time_).count();
 
-    LOG_TRACE("RequestContext",
-              ("Destroying context for request " + std::to_string(id_) +
-               " after " + std::to_string(life_time) + " sec.")
-                  .c_str());
+    EDGE_SDK_LOG_TRACE("RequestContext", ("Destroying context for request " +
+                                          std::to_string(id_) + " after " +
+                                          std::to_string(life_time) + " sec.")
+                                             .c_str());
 #endif
   }
 

--- a/olp-cpp-sdk-core/src/network/ios/HttpClient.mm
+++ b/olp-cpp-sdk-core/src/network/ios/HttpClient.mm
@@ -88,9 +88,8 @@ static NSString* const kMosCACertificateMd5 = @"497904b0eb8719ac47b0bc11519b74d0
     for (NSString* certFile in directoryContents) {
       err = nil;
       NSString* certFilePath = [NSString stringWithFormat:@"%@/%@", certificateDirectory, certFile];
-      NSData* certData = [NSData dataWithContentsOfFile:certFilePath
-                                                options:NSDataReadingMappedIfSafe
-                                                  error:&err];
+      NSData* certData =
+          [NSData dataWithContentsOfFile:certFilePath options:NSDataReadingMappedIfSafe error:&err];
 
       if (!certData || err) {
         continue;
@@ -132,7 +131,7 @@ static NSString* const kMosCACertificateMd5 = @"497904b0eb8719ac47b0bc11519b74d0
 
 @end
 
-@interface HttpClient () <NSURLSessionDataDelegate>
+@interface HttpClient ()<NSURLSessionDataDelegate>
 
 @property(nonatomic, readonly) NSURLSession* sharedUrlSession;  // shared URL session
 @property(nonatomic) NSMutableDictionary* urlSessions;          // request id : NSURLSession object
@@ -153,14 +152,14 @@ static NSString* const kMosCACertificateMd5 = @"497904b0eb8719ac47b0bc11519b74d0
 }
 
 - (void)dealloc {
-  LOG_TRACE(LOGTAG, "HttpClient::dealloc [ " << (__bridge void*)self << " ] ");
+  EDGE_SDK_LOG_TRACE(LOGTAG, "HttpClient::dealloc [ " << (__bridge void*)self << " ] ");
   if (self.sharedUrlSession) {
     [self cleanup];
   }
 }
 
 - (void)cleanup {
-  LOG_TRACE(LOGTAG, "HttpClient::cleanup [ " << (__bridge void*)self << " ] ");
+  EDGE_SDK_LOG_TRACE(LOGTAG, "HttpClient::cleanup [ " << (__bridge void*)self << " ] ");
   [self.sharedUrlSession finishTasksAndInvalidate];
   [self.urlSessions enumerateKeysAndObjectsUsingBlock:^(id key, id object, BOOL* stop) {
     NSURLSession* session = object;
@@ -229,7 +228,7 @@ static NSString* const kMosCACertificateMd5 = @"497904b0eb8719ac47b0bc11519b74d0
     task = _tasks[@(identifier)];
 
     if (!task) {
-      LOG_ERROR(LOGTAG, "cancel unknown request " << identifier);
+      EDGE_SDK_LOG_ERROR(LOGTAG, "cancel unknown request " << identifier);
       return;
     }
   }
@@ -367,7 +366,8 @@ static NSString* const kMosCACertificateMd5 = @"497904b0eb8719ac47b0bc11519b74d0
           return;
         }
         // TODO: Any expert to write lambda here?
-        const olp::network::NetworkSystemConfig& sysConfig = olp::network::Network::SystemConfig().lockedCopy();
+        const olp::network::NetworkSystemConfig& sysConfig =
+            olp::network::Network::SystemConfig().lockedCopy();
         if (!sysConfig.DontVerifyCertificate()) {
           if (![self shouldTrustProtectionSpace:challenge.protectionSpace]) {
             completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
@@ -397,10 +397,10 @@ static NSString* const kMosCACertificateMd5 = @"497904b0eb8719ac47b0bc11519b74d0
 
   NSURLRequest* originalRequest = task.originalRequest;
   NSString* authorizationHeaderValue = originalRequest.allHTTPHeaderFields[@"Authorization"];
-  LOG_TRACE(LOGTAG, "HttpClient::willPerformHTTPRedirection [ "
-                        << (__bridge void*)self << " ] status " << (int)response.statusCode
-                        << "\nOrigURL " << originalRequest.URL.absoluteString.UTF8String
-                        << "\nNewURL " << request.URL.absoluteString.UTF8String);
+  EDGE_SDK_LOG_TRACE(LOGTAG, "HttpClient::willPerformHTTPRedirection [ "
+                                 << (__bridge void*)self << " ] status " << (int)response.statusCode
+                                 << "\nOrigURL " << originalRequest.URL.absoluteString.UTF8String
+                                 << "\nNewURL " << request.URL.absoluteString.UTF8String);
   NSMutableURLRequest* newRequest = [NSMutableURLRequest new];
   newRequest.URL = request.URL;
   newRequest.timeoutInterval = request.timeoutInterval;

--- a/olp-cpp-sdk-core/src/network/ios/HttpTask.mm
+++ b/olp-cpp-sdk-core/src/network/ios/HttpTask.mm
@@ -46,7 +46,8 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
 - (instancetype)initWithId:(int)identifier httpClient:(HttpClient*)client {
   self = [super init];
   if (self) {
-    LOG_TRACE(LOGTAG, "HttpTask::initWithId [ " << (__bridge void*)self << " ] " << identifier);
+    EDGE_SDK_LOG_TRACE(LOGTAG,
+                       "HttpTask::initWithId [ " << (__bridge void*)self << " ] " << identifier);
     _httpClient = client;
     _uniqueId = identifier;
     _requestUrl = [NSMutableString new];
@@ -56,7 +57,8 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
 }
 
 - (void)dealloc {
-  LOG_TRACE(LOGTAG, "HttpTask::dealloc [ " << (__bridge void*)self << " ] " << self.uniqueId);
+  EDGE_SDK_LOG_TRACE(LOGTAG,
+                     "HttpTask::dealloc [ " << (__bridge void*)self << " ] " << self.uniqueId);
 }
 
 - (NSString*)url {
@@ -114,9 +116,10 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
 #ifndef EDGE_SDK_LOGGING_DISABLED
   NSMutableString* debugCurlString = [NSMutableString stringWithString:@"curl -vvv "];
   [debugCurlString appendFormat:@"\"%@\"%@", _requestUrl, debugHeaders];
-  LOG_TRACE(LOGTAG, "HttpTask::run [ " << (__bridge void*)self << " ] "
-                                       << self.dataTask.taskIdentifier << "\t" << request.HTTPMethod
-                                       << "\t" << [debugCurlString UTF8String]);
+  EDGE_SDK_LOG_TRACE(LOGTAG, "HttpTask::run [ " << (__bridge void*)self << " ] "
+                                                << self.dataTask.taskIdentifier << "\t"
+                                                << request.HTTPMethod << "\t"
+                                                << [debugCurlString UTF8String]);
 #endif
 
   [_dataTask resume];
@@ -124,7 +127,8 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
 }
 
 - (BOOL)cancel {
-  LOG_TRACE(LOGTAG, "HttpTask::cancel [ " << (__bridge void*)self << " ] " << self.uniqueId);
+  EDGE_SDK_LOG_TRACE(LOGTAG,
+                     "HttpTask::cancel [ " << (__bridge void*)self << " ] " << self.uniqueId);
 
   BOOL ret = NO;
   @synchronized(self) {
@@ -140,9 +144,9 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
 }
 
 - (void)didCompleteWithError:(NSError*)error {
-  LOG_TRACE(LOGTAG, "HttpTask::didComplete [ " << (__bridge void*)self << " ] "
-                                               << self.dataTask.taskIdentifier << "\t"
-                                               << error.code);
+  EDGE_SDK_LOG_TRACE(LOGTAG, "HttpTask::didComplete [ " << (__bridge void*)self << " ] "
+                                                        << self.dataTask.taskIdentifier << "\t"
+                                                        << error.code);
   HttpTaskCompletionHandler completionHandler = nil;
   @synchronized(self) {
     if (self.completionHandler) {
@@ -164,9 +168,9 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
 - (void)didReceiveResponse:(NSURLResponse*)response {
 #ifndef EDGE_SDK_LOGGING_DISABLED
   NSInteger httpResponseStatusCode = [(NSHTTPURLResponse*)response statusCode];
-  LOG_TRACE(LOGTAG, "HttpTask::didReceiveResponse [ " << (__bridge void*)self << " ] "
-                                                      << self.dataTask.taskIdentifier << "\t"
-                                                      << httpResponseStatusCode);
+  EDGE_SDK_LOG_TRACE(LOGTAG, "HttpTask::didReceiveResponse [ " << (__bridge void*)self << " ] "
+                                                               << self.dataTask.taskIdentifier
+                                                               << "\t" << httpResponseStatusCode);
 #endif
 
   HttpTaskReponseHandler responseHandler = nil;
@@ -183,9 +187,9 @@ NSString* const kHTTPTaskErrorDomain = @"HttpTask";
 }
 
 - (void)didReceiveData:(NSData*)data {
-  LOG_TRACE(LOGTAG, "HttpTask::didReceiveData [ " << (__bridge void*)self << " ] "
-                                                  << self.dataTask.taskIdentifier << "\t"
-                                                  << (unsigned long)data.length);
+  EDGE_SDK_LOG_TRACE(LOGTAG, "HttpTask::didReceiveData [ " << (__bridge void*)self << " ] "
+                                                           << self.dataTask.taskIdentifier << "\t"
+                                                           << (unsigned long)data.length);
 
   // Only print out the strData if debugging needed. It stucks the simulator when running code
   // coverage. NSString *strData = [[NSString alloc] initWithData:data

--- a/olp-cpp-sdk-core/src/network/ios/NetworkProtocolIosImpl.mm
+++ b/olp-cpp-sdk-core/src/network/ios/NetworkProtocolIosImpl.mm
@@ -197,7 +197,7 @@ NetworkProtocol::ErrorCode NetworkProtocolIosImpl::Send(
     // Create task context
     HttpTaskContext* taskContext = [HttpTaskContext new];
     if (!taskContext) {
-      LOG_ERROR(LOGTAG, "Network Out of memory");
+      EDGE_SDK_LOG_ERROR(LOGTAG, "Network Out of memory");
       return NetworkProtocol::ErrorNotReady;
     }
 
@@ -291,18 +291,18 @@ NetworkProtocol::ErrorCode NetworkProtocolIosImpl::Send(
     __weak HttpTask* weakTask = task;
     task.dataHandler = ^(NSData* data) {
       if (!weakTask) {
-        LOG_WARNING(LOGTAG, "Data received after task deleted");
+        EDGE_SDK_LOG_WARNING(LOGTAG, "Data received after task deleted");
         return;
       }
 
       HttpTask* strongTask = weakTask;
       HttpTaskContext* taskContext = strongTask.context;
       if (taskContext.rangeOut) {
-        LOG_TRACE(LOGTAG, "Datacallback out of range");
+        EDGE_SDK_LOG_TRACE(LOGTAG, "Datacallback out of range");
         return;
       }
       size_t len = data.length;
-      LOG_TRACE(LOGTAG, "Received " << len << " bytes");
+      EDGE_SDK_LOG_TRACE(LOGTAG, "Received " << len << " bytes");
 
       if (dataCallback) {
         dataCallback(taskContext.offset + taskContext.count,
@@ -314,7 +314,7 @@ NetworkProtocol::ErrorCode NetworkProtocolIosImpl::Send(
           if (payload->tellp() != std::streampos(taskContext.count)) {
             payload->seekp(taskContext.count);
             if (payload->fail()) {
-              LOG_WARNING(LOGTAG, "Reception stream doesn't support setting write point");
+              EDGE_SDK_LOG_WARNING(LOGTAG, "Reception stream doesn't support setting write point");
               payload->clear();
             }
           }
@@ -328,7 +328,7 @@ NetworkProtocol::ErrorCode NetworkProtocolIosImpl::Send(
 
     task.completionHandler = ^(NSError* error) {
       if (!weakTask) {
-        LOG_WARNING(LOGTAG, "Data received after task deleted");
+        EDGE_SDK_LOG_WARNING(LOGTAG, "Data received after task deleted");
         return;
       }
 
@@ -394,7 +394,7 @@ void NetworkProtocolIosImpl::processResponseHeaders(int identifier, NSHTTPURLRes
 
   HttpTaskContext* taskContext = task.context;
   if (!task || !taskContext) {
-    LOG_ERROR(LOGTAG, "Unexpected response headers");
+    EDGE_SDK_LOG_ERROR(LOGTAG, "Unexpected response headers");
     return;
   }
 
@@ -512,10 +512,10 @@ void NetworkProtocolIosImpl::processResponseHeaders(int identifier, NSHTTPURLRes
         taskContext.offset = std::stoll(countStr.substr(6));
       }
     } else {
-      LOG_WARNING(LOGTAG, "Invalid Content-Range header: " << countStr);
+      EDGE_SDK_LOG_WARNING(LOGTAG, "Invalid Content-Range header: " << countStr);
     }
   } else {
-    LOG_WARNING(LOGTAG, "Invalid Content-Range header: " << countString);
+    EDGE_SDK_LOG_WARNING(LOGTAG, "Invalid Content-Range header: " << countString);
   }
 }
 

--- a/olp-cpp-sdk-core/src/network/socket/NetworkConnectivitySocketImpl.cpp
+++ b/olp-cpp-sdk-core/src/network/socket/NetworkConnectivitySocketImpl.cpp
@@ -41,17 +41,17 @@ bool canConnectToAddress(const sockaddr_in& dsockaddr) {
 #ifndef _WIN32
   int socket_desc = socket(dsockaddr.sin_family, SOCK_STREAM, 0);
   if (socket_desc == -1) {
-    LOG_WARNING(LOG_TAG, "socket() failed for ip address "
-                             << inet_ntoa(dsockaddr.sin_addr) << ": "
-                             << strerror(errno));
+    EDGE_SDK_LOG_WARNING(LOG_TAG, "socket() failed for ip address "
+                                      << inet_ntoa(dsockaddr.sin_addr) << ": "
+                                      << strerror(errno));
     return false;
   }
 
   if (connect(socket_desc, (struct sockaddr*)&dsockaddr, sizeof(dsockaddr)) ==
       -1) {
-    LOG_WARNING(LOG_TAG, "connect() failed for ip address "
-                             << inet_ntoa(dsockaddr.sin_addr) << ": "
-                             << strerror(errno));
+    EDGE_SDK_LOG_WARNING(LOG_TAG, "connect() failed for ip address "
+                                      << inet_ntoa(dsockaddr.sin_addr) << ": "
+                                      << strerror(errno));
     close(socket_desc);
     return false;
   }
@@ -61,17 +61,17 @@ bool canConnectToAddress(const sockaddr_in& dsockaddr) {
   SOCKET socket_desc = INVALID_SOCKET;
   socket_desc = socket(dsockaddr.sin_family, SOCK_STREAM, IPPROTO_TCP);
   if (socket_desc == INVALID_SOCKET) {
-    LOG_WARNING(LOG_TAG, "socket() failed for ip address "
-                             << inet_ntoa(dsockaddr.sin_addr) << ": "
-                             << strerror(errno));
+    EDGE_SDK_LOG_WARNING(LOG_TAG, "socket() failed for ip address "
+                                      << inet_ntoa(dsockaddr.sin_addr) << ": "
+                                      << strerror(errno));
     return false;
   }
 
   if (connect(socket_desc, (struct sockaddr*)&dsockaddr, sizeof(dsockaddr)) ==
       SOCKET_ERROR) {
-    LOG_WARNING(LOG_TAG, "connect() failed for ip address "
-                             << inet_ntoa(dsockaddr.sin_addr) << ": "
-                             << strerror(errno));
+    EDGE_SDK_LOG_WARNING(LOG_TAG, "connect() failed for ip address "
+                                      << inet_ntoa(dsockaddr.sin_addr) << ": "
+                                      << strerror(errno));
     closesocket(socket_desc);
     return false;
   }

--- a/olp-cpp-sdk-core/src/network/winhttp/NetworkProtocolWinHttp.cpp
+++ b/olp-cpp-sdk-core/src/network/winhttp/NetworkProtocolWinHttp.cpp
@@ -184,7 +184,7 @@ bool NetworkProtocolWinHttp::Initialize() {
                           WINHTTP_FLAG_ASYNC);
 
   if (!m_session) {
-    LOG_ERROR(LOGTAG, "WinHttpOpen failed " << GetLastError());
+    EDGE_SDK_LOG_ERROR(LOGTAG, "WinHttpOpen failed " << GetLastError());
     return false;
   }
 
@@ -292,7 +292,7 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
 
   std::wstring url(request.Url().begin(), request.Url().end());
   if (!WinHttpCrackUrl(url.c_str(), (DWORD)url.length(), 0, &urlComponents)) {
-    LOG_ERROR(LOGTAG, "WinHttpCrackUrl failed " << GetLastError());
+    EDGE_SDK_LOG_ERROR(LOGTAG, "WinHttpCrackUrl failed " << GetLastError());
     return olp::network::NetworkProtocol::ErrorInvalidRequest;
   }
 
@@ -332,7 +332,7 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
 
   if ((urlComponents.nScheme != INTERNET_SCHEME_HTTP) &&
       (urlComponents.nScheme != INTERNET_SCHEME_HTTPS)) {
-    LOG_ERROR(LOGTAG, "Invalid scheme on request " << request.Url());
+    EDGE_SDK_LOG_ERROR(LOGTAG, "Invalid scheme on request " << request.Url());
 
     std::unique_lock<std::recursive_mutex> lock(m_mutex);
 
@@ -371,7 +371,7 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
       handle->m_connection->m_connect, httpVerb, urlComponents.lpszUrlPath,
       NULL, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, flags);
   if (!httpRequest) {
-    LOG_ERROR(LOGTAG, "WinHttpOpenRequest failed " << GetLastError());
+    EDGE_SDK_LOG_ERROR(LOGTAG, "WinHttpOpenRequest failed " << GetLastError());
 
     std::unique_lock<std::recursive_mutex> lock(m_mutex);
 
@@ -398,7 +398,8 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
             SECURITY_FLAG_IGNORE_UNKNOWN_CA;
     if (!WinHttpSetOption(httpRequest, WINHTTP_OPTION_SECURITY_FLAGS, &flags,
                           sizeof(flags))) {
-      LOG_ERROR(LOGTAG, "WinHttpSetOption(Security) failed " << GetLastError());
+      EDGE_SDK_LOG_ERROR(
+          LOGTAG, "WinHttpSetOption(Security) failed " << GetLastError());
     }
   }
 
@@ -445,7 +446,8 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
     if (!WinHttpSetOption(httpRequest, WINHTTP_OPTION_PROXY, &proxy_info,
                           sizeof(proxy_info))) {
       error_code = GetLastError();
-      LOG_ERROR(LOGTAG, "WinHttpSetOption(Proxy) failed " << error_code);
+      EDGE_SDK_LOG_ERROR(LOGTAG,
+                         "WinHttpSetOption(Proxy) failed " << error_code);
     }
     if (!proxy->UserName().empty() && !proxy->UserPassword().empty()) {
       std::wstring proxy_username;
@@ -462,8 +464,8 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
                               const_cast<LPWSTR>(proxy_lpcwstr_username),
                               wcslen(proxy_lpcwstr_username))) {
           error_code = GetLastError();
-          LOG_ERROR(LOGTAG,
-                    "WinHttpSetOption(proxy username) failed " << error_code);
+          EDGE_SDK_LOG_ERROR(
+              LOGTAG, "WinHttpSetOption(proxy username) failed " << error_code);
         }
 
         LPCWSTR proxy_lpcwstr_password = proxy_password.c_str();
@@ -471,17 +473,19 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
                               const_cast<LPWSTR>(proxy_lpcwstr_password),
                               wcslen(proxy_lpcwstr_password))) {
           error_code = GetLastError();
-          LOG_ERROR(LOGTAG,
-                    "WinHttpSetOption(proxy password) failed " << error_code);
+          EDGE_SDK_LOG_ERROR(
+              LOGTAG, "WinHttpSetOption(proxy password) failed " << error_code);
         }
       } else {
         if (!username_res) {
           error_code = GetLastError();
-          LOG_ERROR(LOGTAG, "Proxy username conversion failure " << error_code);
+          EDGE_SDK_LOG_ERROR(
+              LOGTAG, "Proxy username conversion failure " << error_code);
         }
         if (!password_res) {
           error_code = GetLastError();
-          LOG_ERROR(LOGTAG, "Proxy password conversion failure " << error_code);
+          EDGE_SDK_LOG_ERROR(
+              LOGTAG, "Proxy password conversion failure " << error_code);
         }
       }
     }
@@ -522,7 +526,8 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
 
   if (!WinHttpAddRequestHeaders(httpRequest, headerStrm.str().c_str(),
                                 DWORD(-1), WINHTTP_ADDREQ_FLAG_ADD)) {
-    LOG_ERROR(LOGTAG, "WinHttpAddRequestHeaders() failed " << GetLastError());
+    EDGE_SDK_LOG_ERROR(LOGTAG,
+                       "WinHttpAddRequestHeaders() failed " << GetLastError());
   }
 
   if (request.ModifiedSince()) {
@@ -537,8 +542,9 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
       headerStrm << pwszTimeStr;
       if (!WinHttpAddRequestHeaders(httpRequest, headerStrm.str().c_str(),
                                     DWORD(-1), WINHTTP_ADDREQ_FLAG_ADD)) {
-        LOG_ERROR(LOGTAG, "WinHttpAddRequestHeaders(if-modified-since) failed "
-                              << GetLastError());
+        EDGE_SDK_LOG_ERROR(LOGTAG,
+                           "WinHttpAddRequestHeaders(if-modified-since) failed "
+                               << GetLastError());
       }
     }
   }
@@ -547,7 +553,7 @@ olp::network::NetworkProtocol::ErrorCode NetworkProtocolWinHttp::Send(
   if (!WinHttpSendRequest(httpRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0,
                           (LPVOID)content, contentLength, contentLength,
                           (DWORD_PTR)handle.get())) {
-    LOG_ERROR(LOGTAG, "WinHttpSendRequest failed " << GetLastError());
+    EDGE_SDK_LOG_ERROR(LOGTAG, "WinHttpSendRequest failed " << GetLastError());
 
     std::unique_lock<std::recursive_mutex> lock(m_mutex);
 
@@ -582,7 +588,7 @@ void NetworkProtocolWinHttp::requestCallback(HINTERNET, DWORD_PTR context,
 
   RequestData* handle = reinterpret_cast<RequestData*>(context);
   if (!handle->m_connection || !handle->m_result) {
-    LOG_WARNING(LOGTAG, "RequestCallback to inactive handle");
+    EDGE_SDK_LOG_WARNING(LOGTAG, "RequestCallback to inactive handle");
     return;
   }
 
@@ -770,9 +776,10 @@ void NetworkProtocolWinHttp::requestCallback(HINTERNET, DWORD_PTR context,
               handle->m_strm.next_in = Z_NULL;
               inflateInit2(&handle->m_strm, 16 + MAX_WBITS);
 #else
-              LOG_ERROR(LOGTAG,
-                        "Gzip encoding but compression no supported and no "
-                        "ZLIB found");
+              EDGE_SDK_LOG_ERROR(
+                  LOGTAG,
+                  "Gzip encoding but compression no supported and no "
+                  "ZLIB found");
 #endif
             }
             LocalFree(str);
@@ -793,7 +800,8 @@ void NetworkProtocolWinHttp::requestCallback(HINTERNET, DWORD_PTR context,
       // Data is available read it
       LPVOID buffer = (LPVOID)LocalAlloc(LPTR, size);
       if (!buffer) {
-        LOG_ERROR(LOGTAG, "Out of memory reeceiving " << size << " bytes");
+        EDGE_SDK_LOG_ERROR(LOGTAG,
+                           "Out of memory reeceiving " << size << " bytes");
         handle->m_result->m_status = ERROR_NOT_ENOUGH_MEMORY;
         handle->complete();
         return;
@@ -836,7 +844,7 @@ void NetworkProtocolWinHttp::requestCallback(HINTERNET, DWORD_PTR context,
           int r = inflate(&handle->m_strm, Z_NO_FLUSH);
 
           if ((r != Z_OK) && (r != Z_STREAM_END)) {
-            LOG_ERROR(LOGTAG, "Uncompression failed");
+            EDGE_SDK_LOG_ERROR(LOGTAG, "Uncompression failed");
             LocalFree((HLOCAL)compressed);
             LocalFree((HLOCAL)dataBuffer);
             handle->m_result->m_status = ERROR_INVALID_BLOCK;
@@ -877,7 +885,7 @@ void NetworkProtocolWinHttp::requestCallback(HINTERNET, DWORD_PTR context,
                   std::streampos(handle->m_result->m_count)) {
                 handle->m_payload->seekp(handle->m_result->m_count);
                 if (handle->m_payload->fail()) {
-                  LOG_WARNING(
+                  EDGE_SDK_LOG_WARNING(
                       LOGTAG,
                       "Reception stream doesn't support setting write point");
                   handle->m_payload->clear();
@@ -901,7 +909,8 @@ void NetworkProtocolWinHttp::requestCallback(HINTERNET, DWORD_PTR context,
     handle->freeHandle();
     return;
   } else {
-    LOG_ERROR(LOGTAG, "Unknown callback " << std::hex << status << std::dec);
+    EDGE_SDK_LOG_ERROR(LOGTAG,
+                       "Unknown callback " << std::hex << status << std::dec);
   }
 }
 

--- a/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
+++ b/olp-cpp-sdk-core/src/thread/ThreadPoolTaskScheduler.cpp
@@ -73,7 +73,7 @@ ThreadPoolTaskScheduler::ThreadPoolTaskScheduler(size_t thread_count) {
       // Set thread name for easy profiling and debugging
       std::string thread_name = "OLPSDKPOOL_" + std::to_string(idx);
       SetCurrentThreadName(thread_name);
-      LOG_INFO_F(kLogTag, "Starting thread '%s'", thread_name.c_str());
+      EDGE_SDK_LOG_INFO_F(kLogTag, "Starting thread '%s'", thread_name.c_str());
 
       for (;;) {
         TaskScheduler::CallFuncType task;


### PR DESCRIPTION
All instances of loggging macros usage in olp-cpp-sdk-core now utilize
ones with EDGE_SDK prefix.

Relates-to: OLPEDGE-407

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>