### PR TITLE
Logging prefix for 'dataservice-read' subproject

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/ApiClientLookup.cpp
@@ -49,15 +49,16 @@ CancellationToken ApiClientLookup::LookupApi(std::shared_ptr<OlpClient> client,
                                              const std::string& service_version,
                                              const HRN& hrn,
                                              const ApisCallback& callback) {
-  LOG_TRACE_F(kLogTag, "LookupApi(%s/%s): %s", service.c_str(),
-              service_version.c_str(), hrn.partition.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "LookupApi(%s/%s): %s", service.c_str(),
+                       service_version.c_str(), hrn.partition.c_str());
   // compare the hrn
   const auto& datastoreServerUrl = getDatastoreServerUrl();
   auto findResult = datastoreServerUrl.find(hrn.partition);
 
   if (findResult == datastoreServerUrl.cend()) {
-    LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s could not find HRN",
-               service.c_str(), service_version.c_str(), hrn.partition.c_str());
+    EDGE_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s could not find HRN",
+                        service.c_str(), service_version.c_str(),
+                        hrn.partition.c_str());
     callback(ApiError(ErrorCode::NotFound,
                       std::string()));  // TODO better error description?
     return CancellationToken();
@@ -67,9 +68,9 @@ CancellationToken ApiClientLookup::LookupApi(std::shared_ptr<OlpClient> client,
 
     if (service == "config") {
       // scan apis at platform apis
-      LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - config service",
-                 service.c_str(), service_version.c_str(),
-                 hrn.partition.c_str());
+      EDGE_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - config service",
+                          service.c_str(), service_version.c_str(),
+                          hrn.partition.c_str());
       return PlatformApi::GetApis(
           client, service, service_version,
           [callback](PlatformApi::ApisResponse response) {
@@ -77,9 +78,9 @@ CancellationToken ApiClientLookup::LookupApi(std::shared_ptr<OlpClient> client,
           });
     } else {
       // scan apis at resource endpoint
-      LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - resource service",
-                 service.c_str(), service_version.c_str(),
-                 hrn.partition.c_str());
+      EDGE_SDK_LOG_INFO_F(kLogTag, "LookupApi(%s/%s): %s - resource service",
+                          service.c_str(), service_version.c_str(),
+                          hrn.partition.c_str());
       return ResourcesApi::GetApis(
           client, hrn.ToCatalogHRNString(), service, service_version,
           [callback](PlatformApi::ApisResponse response) {
@@ -93,29 +94,29 @@ CancellationToken ApiClientLookup::LookupApiClient(
     std::shared_ptr<OlpClient> client, const std::string& service,
     const std::string& service_version, const HRN& hrn,
     const ApiClientCallback& callback) {
-  LOG_TRACE_F(kLogTag, "LookupApiClient(%s/%s): %s", service.c_str(),
-              service_version.c_str(), hrn.partition.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "LookupApiClient(%s/%s): %s", service.c_str(),
+                       service_version.c_str(), hrn.partition.c_str());
   return ApiClientLookup::LookupApi(
       client, service, service_version, hrn,
 
       [client, callback, service, service_version, hrn](ApisResponse response) {
         if (!response.IsSuccessful()) {
-          LOG_INFO_F(
+          EDGE_SDK_LOG_INFO_F(
               kLogTag, "LookupApiClient(%s/%s): %s - unsuccessful: %s",
               service.c_str(), service_version.c_str(), hrn.partition.c_str(),
               response.GetError().GetMessage().c_str());
           callback(response.GetError());
         } else if (response.GetResult().size() < 1) {
-          LOG_INFO_F(
+          EDGE_SDK_LOG_INFO_F(
               kLogTag, "LookupApiClient(%s/%s): %s - service not available",
               service.c_str(), service_version.c_str(), hrn.partition.c_str());
           // TODO use defined ErrorCode
           callback(ApiError(ErrorCode::ServiceUnavailable,
                             "Service/Version not available for given HRN"));
         } else {
-          LOG_INFO_F(kLogTag, "LookupApiClient(%s/%s): %s - OK",
-                     service.c_str(), service_version.c_str(),
-                     hrn.partition.c_str());
+          EDGE_SDK_LOG_INFO_F(kLogTag, "LookupApiClient(%s/%s): %s - OK",
+                              service.c_str(), service_version.c_str(),
+                              hrn.partition.c_str());
           client->SetBaseUrl(response.GetResult().at(0).GetBaseUrl());
           callback(*(client.get()));
         }

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -68,19 +68,19 @@ CatalogClientImpl::CatalogClientImpl(
 CatalogClientImpl::~CatalogClientImpl() { CancelPendingRequests(); }
 
 bool CatalogClientImpl::CancelPendingRequests() {
-  LOG_TRACE(kLogTag, "CancelPendingRequests");
+  EDGE_SDK_LOG_TRACE(kLogTag, "CancelPendingRequests");
   return pending_requests_->CancelPendingRequests();
 }
 
 CancellationToken CatalogClientImpl::GetCatalog(
     const CatalogRequest& request, const CatalogResponseCallback& callback) {
-  LOG_TRACE_F(kLogTag, "GetCatalog '%s'", request.CreateKey().c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetCatalog '%s'", request.CreateKey().c_str());
   CancellationToken token;
   int64_t request_key = pending_requests_->GenerateKey();
   auto pending_requests = pending_requests_;
   auto request_callback = [pending_requests, request_key,
                            callback](CatalogResponse response) {
-    LOG_INFO_F(kLogTag, "GetCatalog remove key: %ld", request_key);
+    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog remove key: %ld", request_key);
     pending_requests->Remove(request_key);
     callback(response);
   };
@@ -89,7 +89,7 @@ CancellationToken CatalogClientImpl::GetCatalog(
     token = catalog_repo_->getCatalog(req.WithFetchOption(CacheOnly),
                                       request_callback);
     auto onlineKey = pending_requests_->GenerateKey();
-    LOG_INFO_F(kLogTag, "GetCatalog add key: %ld", onlineKey);
+    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog add key: %ld", onlineKey);
     pending_requests_->Add(catalog_repo_->getCatalog(
                                req.WithFetchOption(OnlineIfNotFound),
                                [pending_requests, onlineKey](CatalogResponse) {
@@ -97,7 +97,7 @@ CancellationToken CatalogClientImpl::GetCatalog(
                                }),
                            onlineKey);
   } else {
-    LOG_INFO_F(kLogTag, "GetCatalog existing: %ld", request_key);
+    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog existing: %ld", request_key);
     token = catalog_repo_->getCatalog(request, request_callback);
   }
   pending_requests_->Add(token, request_key);
@@ -115,13 +115,13 @@ CancellableFuture<CatalogResponse> CatalogClientImpl::GetCatalog(
 CancellationToken CatalogClientImpl::GetCatalogMetadataVersion(
     const CatalogVersionRequest& request,
     const CatalogVersionCallback& callback) {
-  LOG_TRACE_F(kLogTag, "GetCatalog '%s'", request.CreateKey().c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetCatalog '%s'", request.CreateKey().c_str());
   CancellationToken token;
   int64_t request_key = pending_requests_->GenerateKey();
   auto pending_requests = pending_requests_;
   auto request_callback = [pending_requests, request_key,
                            callback](CatalogVersionResponse response) {
-    LOG_INFO_F(kLogTag, "GetCatalog remove key: %ld", request_key);
+    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog remove key: %ld", request_key);
     pending_requests->Remove(request_key);
     callback(response);
   };
@@ -130,7 +130,7 @@ CancellationToken CatalogClientImpl::GetCatalogMetadataVersion(
     token = catalog_repo_->getLatestCatalogVersion(
         req.WithFetchOption(CacheOnly), request_callback);
     auto onlineKey = pending_requests_->GenerateKey();
-    LOG_INFO_F(kLogTag, "GetCatalog add key: %ld", onlineKey);
+    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog add key: %ld", onlineKey);
     pending_requests_->Add(
         catalog_repo_->getLatestCatalogVersion(
             req.WithFetchOption(OnlineIfNotFound),
@@ -139,7 +139,7 @@ CancellationToken CatalogClientImpl::GetCatalogMetadataVersion(
             }),
         onlineKey);
   } else {
-    LOG_INFO_F(kLogTag, "GetCatalog existing: %ld", request_key);
+    EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog existing: %ld", request_key);
     token = catalog_repo_->getLatestCatalogVersion(request, request_callback);
   }
   pending_requests_->Add(token, request_key);

--- a/olp-cpp-sdk-dataservice-read/src/MultiRequestContext.h
+++ b/olp-cpp-sdk-dataservice-read/src/MultiRequestContext.h
@@ -58,9 +58,9 @@ class MultiRequestContext final {
 
     while (!active_reqs_->empty()) {
       auto itr = active_reqs_->begin();
-      LOG_INFO_F(kMultiRequestContextLogTag,
-                 "~MultiRequestContext() -> cancelling id %s",
-                 itr->first.c_str());
+      EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                          "~MultiRequestContext() -> cancelling id %s",
+                          itr->first.c_str());
       itr->second->cancellation_token_.cancel();
     }
   }
@@ -71,9 +71,10 @@ class MultiRequestContext final {
       Callback callback_fn) {
     boost::uuids::uuid request_id = uuid_gen_();
 
-    LOG_TRACE_F(kMultiRequestContextLogTag,
-                "ExecuteOrAssociate(%s) -> request uuid = %s", key.c_str(),
-                boost::uuids::to_string(request_id).c_str());
+    EDGE_SDK_LOG_TRACE_F(kMultiRequestContextLogTag,
+                         "ExecuteOrAssociate(%s) -> request uuid = %s",
+                         key.c_str(),
+                         boost::uuids::to_string(request_id).c_str());
 
     std::shared_ptr<RequestContext> newContext;
 
@@ -82,14 +83,15 @@ class MultiRequestContext final {
 
       auto itr = active_reqs_->find(key);
       if (itr != active_reqs_->end()) {
-        LOG_INFO_F(kMultiRequestContextLogTag,
-                   "ExecuteOrAssociate(%s) -> existing request key",
-                   key.c_str());
+        EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                            "ExecuteOrAssociate(%s) -> existing request key",
+                            key.c_str());
 
         itr->second->callbacks_[request_id] = callback_fn;
       } else {
-        LOG_INFO_F(kMultiRequestContextLogTag,
-                   "ExecuteOrAssociate(%s) -> new request key", key.c_str());
+        EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                            "ExecuteOrAssociate(%s) -> new request key",
+                            key.c_str());
 
         newContext = std::make_shared<RequestContext>();
         newContext->callbacks_[request_id] = callback_fn;
@@ -105,8 +107,9 @@ class MultiRequestContext final {
         onRequestCompleted(mutex, reqs, response, key);
       };
 
-      LOG_INFO_F(kMultiRequestContextLogTag,
-                 "ExecuteOrAssociate(%s) -> execute request()", key.c_str());
+      EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                          "ExecuteOrAssociate(%s) -> execute request()",
+                          key.c_str());
 
       newContext->cancellation_token_ = execute_fn(callback);
     }
@@ -135,8 +138,8 @@ class MultiRequestContext final {
   static void onRequestCompleted(std::shared_ptr<std::recursive_mutex> mutex,
                                  ReqsPtr reqs, Response response,
                                  std::string key) {
-    LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCompleted(%s)",
-                key.c_str());
+    EDGE_SDK_LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCompleted(%s)",
+                         key.c_str());
     RequestContextPtr context;
 
     {
@@ -150,9 +153,9 @@ class MultiRequestContext final {
     }  // release the lock, then invoke the callbacks.
 
     if (context) {
-      LOG_INFO_F(kMultiRequestContextLogTag,
-                 "onRequestCompleted(%s) -> callback count = %lu", key.c_str(),
-                 context->callbacks_.size());
+      EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                          "onRequestCompleted(%s) -> callback count = %lu",
+                          key.c_str(), context->callbacks_.size());
 
       for (auto& callback : context->callbacks_) {
         callback.second(response);
@@ -164,8 +167,8 @@ class MultiRequestContext final {
                                  std::shared_ptr<std::recursive_mutex> mutex,
                                  ReqsPtr reqs, const std::string& key,
                                  const boost::uuids::uuid& request_id) {
-    LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCancelled(%s)",
-                key.c_str());
+    EDGE_SDK_LOG_TRACE_F(kMultiRequestContextLogTag, "onRequestCancelled(%s)",
+                         key.c_str());
     RequestContextPtr context;
 
     {
@@ -179,9 +182,9 @@ class MultiRequestContext final {
     }  // release the lock, then invoke the callbacks.
 
     if (context) {
-      LOG_INFO_F(kMultiRequestContextLogTag,
-                 "onRequestCancelled(key=%s, id=%s)", key.c_str(),
-                 boost::uuids::to_string(request_id).c_str());
+      EDGE_SDK_LOG_INFO_F(kMultiRequestContextLogTag,
+                          "onRequestCancelled(key=%s, id=%s)", key.c_str(),
+                          boost::uuids::to_string(request_id).c_str());
 
       // find the callback by request_id
       auto requestItr = context->callbacks_.find(request_id);

--- a/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/generated/api/QueryApi.cpp
@@ -123,17 +123,18 @@ client::CancellationToken QueryApi::QuadTreeIndex(
                             std::to_string(version) + "/quadkeys/" + quadKey +
                             "/depths/" + std::to_string(depth);
 
-  NetworkAsyncCallback callback = [indexCallback](
-                                      network::HttpResponse response) {
-    LOG_TRACE_F(LOGTAG, "QuadTreeIndex callback, status=%d", response.status);
-    if (response.status != 200) {
-      indexCallback(ApiError(response.status, response.response));
-    } else {
-      indexCallback(olp::parser::parse<model::Index>(response.response));
-    }
-  };
+  NetworkAsyncCallback callback =
+      [indexCallback](network::HttpResponse response) {
+        EDGE_SDK_LOG_TRACE_F(LOGTAG, "QuadTreeIndex callback, status=%d",
+                             response.status);
+        if (response.status != 200) {
+          indexCallback(ApiError(response.status, response.response));
+        } else {
+          indexCallback(olp::parser::parse<model::Index>(response.response));
+        }
+      };
 
-  LOG_TRACE(LOGTAG, "QuadTreeIndex");
+  EDGE_SDK_LOG_TRACE(LOGTAG, "QuadTreeIndex");
 
   return client.CallApi(metadataUri, "GET", queryParams, headerParams,
                         formParams, nullptr, "", callback);

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiCacheRepository.cpp
@@ -45,7 +45,7 @@ void ApiCacheRepository::Put(const std::string& service,
                              const std::string& serviceUrl) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, service, serviceVersion);
-  LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
   cache_->Put(CreateKey(hrn, service, serviceVersion), serviceUrl,
               [serviceUrl]() { return serviceUrl; }, 3600);
 }
@@ -54,7 +54,7 @@ boost::optional<std::string> ApiCacheRepository::Get(
     const std::string& service, const std::string& serviceVersion) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, service, serviceVersion);
-  LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
   auto url = cache_->Get(key, [](const std::string& value) { return value; });
   if (url.empty()) {
     return boost::none;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.cpp
@@ -51,13 +51,13 @@ ApiRepository::ApiRepository(
 olp::client::CancellationToken ApiRepository::getApiClient(
     const std::string& service, const std::string& serviceVersion,
     const ApiClientCallback& callback) {
-  LOG_TRACE_F(kLogTag, "getApiClient(%s, %s)", service.c_str(),
-              serviceVersion.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "getApiClient(%s, %s)", service.c_str(),
+                       serviceVersion.c_str());
 
   auto url = cache_->Get(service, serviceVersion);
   if (url) {
-    LOG_INFO_F(kLogTag, "getApiClient(%s, %s) -> from cache", service.c_str(),
-               serviceVersion.c_str());
+    EDGE_SDK_LOG_INFO_F(kLogTag, "getApiClient(%s, %s) -> from cache",
+                        service.c_str(), serviceVersion.c_str());
 
     auto client = olp::client::OlpClientFactory::Create(*settings_);
     client->SetBaseUrl(*url);
@@ -71,20 +71,20 @@ olp::client::CancellationToken ApiRepository::getApiClient(
   MultiRequestContext<ApiClientResponse, ApiClientCallback>::ExecuteFn
       executeFn = [cache, hrn, settings, service,
                    serviceVersion](ApiClientCallback contextCallback) {
-        LOG_INFO_F(kLogTag, "getApiClient(%s, %s) -> execute", service.c_str(),
-                   serviceVersion.c_str());
+        EDGE_SDK_LOG_INFO_F(kLogTag, "getApiClient(%s, %s) -> execute",
+                            service.c_str(), serviceVersion.c_str());
 
-        auto cacheApiResponseCallback =
-            [cache, hrn, settings, service, serviceVersion,
-             contextCallback](ApiClientResponse response) {
-              if (response.IsSuccessful()) {
-                LOG_INFO_F(kLogTag, "getApiClient(%s, %s) -> into cache",
-                           service.c_str(), serviceVersion.c_str());
-                cache->Put(service, serviceVersion,
-                           response.GetResult().GetBaseUrl());
-              }
-              contextCallback(response);
-            };
+        auto cacheApiResponseCallback = [cache, hrn, settings, service,
+                                         serviceVersion, contextCallback](
+                                            ApiClientResponse response) {
+          if (response.IsSuccessful()) {
+            EDGE_SDK_LOG_INFO_F(kLogTag, "getApiClient(%s, %s) -> into cache",
+                                service.c_str(), serviceVersion.c_str());
+            cache->Put(service, serviceVersion,
+                       response.GetResult().GetBaseUrl());
+          }
+          contextCallback(response);
+        };
 
         return olp::dataservice::read::ApiClientLookup::LookupApiClient(
             olp::client::OlpClientFactory::Create(*settings), service,

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogCacheRepository.cpp
@@ -54,7 +54,7 @@ CatalogCacheRepository::CatalogCacheRepository(
 void CatalogCacheRepository::Put(const model::Catalog& catalog) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn);
-  LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
   cache_->Put(key, catalog,
               [catalog]() { return olp::serializer::serialize(catalog); });
 }
@@ -62,7 +62,7 @@ void CatalogCacheRepository::Put(const model::Catalog& catalog) {
 boost::optional<model::Catalog> CatalogCacheRepository::Get() {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn);
-  LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
   auto cachedCatalog =
       cache_->Get(key, [](const std::string& serializedObject) {
         return parser::parse<model::Catalog>(serializedObject);
@@ -76,7 +76,7 @@ boost::optional<model::Catalog> CatalogCacheRepository::Get() {
 
 void CatalogCacheRepository::PutVersion(const model::VersionResponse& version) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  LOG_TRACE_F(kLogTag, "PutVersion '%s'", hrn.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "PutVersion '%s'", hrn.c_str());
   cache_->Put(VersionKey(hrn), version,
               [version]() { return olp::serializer::serialize(version); });
 }
@@ -84,7 +84,7 @@ void CatalogCacheRepository::PutVersion(const model::VersionResponse& version) {
 boost::optional<model::VersionResponse> CatalogCacheRepository::GetVersion() {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = VersionKey(hrn);
-  LOG_TRACE_F(kLogTag, "GetVersion '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetVersion '%s'", key.c_str());
   auto cachedVersion =
       cache_->Get(key, [](const std::string& serializedObject) {
         return parser::parse<model::VersionResponse>(serializedObject);
@@ -97,7 +97,7 @@ boost::optional<model::VersionResponse> CatalogCacheRepository::GetVersion() {
 
 void CatalogCacheRepository::Clear() {
   std::string hrn(hrn_.ToCatalogHRNString());
-  LOG_TRACE_F(kLogTag, "Clear '%s'", CreateKey(hrn).c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Clear '%s'", CreateKey(hrn).c_str());
   cache_->RemoveKeysWithPrefix(hrn);
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataCacheRepository.cpp
@@ -45,7 +45,7 @@ void DataCacheRepository::Put(const model::Data& data,
                               const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", key.c_str());
   cache_->Put(key, data);
 }
 
@@ -53,7 +53,7 @@ boost::optional<model::Data> DataCacheRepository::Get(
     const std::string& layer_id, const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
   auto cachedData = cache_->Get(key);
   if (!cachedData) {
     return boost::none;
@@ -66,7 +66,7 @@ void DataCacheRepository::Clear(const std::string& layer_id,
                                 const std::string& data_handle) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, data_handle);
-  LOG_TRACE_F(kLogTag, "Clear '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Clear '%s'", key.c_str());
   cache_->RemoveKeysWithPrefix(key);
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/DataRepository.cpp
@@ -52,21 +52,21 @@ void GetDataInternal(std::shared_ptr<CancellationContext> cancellationContext,
   std::string service;
   std::function<CancellationToken(const OlpClient&)> dataFunc;
   auto key = request.CreateKey();
-  LOG_TRACE_F(kLogTag, "GetDataInternal '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetDataInternal '%s'", key.c_str());
   auto cancel_callback = [callback, key]() {
-    LOG_INFO_F(kLogTag, "cancelled '%s'", key.c_str());
+    EDGE_SDK_LOG_INFO_F(kLogTag, "cancelled '%s'", key.c_str());
     callback({{ErrorCode::Cancelled, "Operation cancelled.", true}});
   };
 
   /* Cache put intercept */
   auto cacheDataResponseCallback = [=, &cache](DataResponse response) {
     if (response.IsSuccessful()) {
-      LOG_INFO_F(kLogTag, "put '%s' to cache", key.c_str());
+      EDGE_SDK_LOG_INFO_F(kLogTag, "put '%s' to cache", key.c_str());
       cache.Put(response.GetResult(), request.GetLayerId(),
                 request.GetDataHandle().value_or(std::string()));
     } else {
       if (403 == response.GetError().GetHttpStatusCode()) {
-        LOG_INFO_F(kLogTag, "clear '%s' cache", key.c_str());
+        EDGE_SDK_LOG_INFO_F(kLogTag, "clear '%s' cache", key.c_str());
         cache.Clear(request.GetLayerId(),
                     request.GetDataHandle().value_or(std::string()));
       }
@@ -77,7 +77,7 @@ void GetDataInternal(std::shared_ptr<CancellationContext> cancellationContext,
   if (layerType == "versioned") {
     service = "blob";
     dataFunc = [=](const OlpClient& client) {
-      LOG_INFO_F(kLogTag, "getBlob '%s", key.c_str());
+      EDGE_SDK_LOG_INFO_F(kLogTag, "getBlob '%s", key.c_str());
       return BlobApi::GetBlob(client, request.GetLayerId(),
                               *request.GetDataHandle(), request.GetBillingTag(),
                               boost::none, cacheDataResponseCallback);
@@ -85,14 +85,14 @@ void GetDataInternal(std::shared_ptr<CancellationContext> cancellationContext,
   } else if (layerType == "volatile") {
     service = "volatile-blob";
     dataFunc = [=](const OlpClient& client) {
-      LOG_INFO_F(kLogTag, "getVolatileBlob '%s", key.c_str());
+      EDGE_SDK_LOG_INFO_F(kLogTag, "getVolatileBlob '%s", key.c_str());
       return VolatileBlobApi::GetVolatileBlob(
           client, request.GetLayerId(), *request.GetDataHandle(),
           request.GetBillingTag(), cacheDataResponseCallback);
     };
   } else {
     // TODO handle stream api
-    LOG_INFO_F(kLogTag, "service unavailable '%s'", key.c_str());
+    EDGE_SDK_LOG_INFO_F(kLogTag, "service unavailable '%s'", key.c_str());
     callback(ApiError(client::ErrorCode::ServiceUnavailable,
                       "Stream layers are not supported yet."));
     return;
@@ -107,14 +107,16 @@ void GetDataInternal(std::shared_ptr<CancellationContext> cancellationContext,
                         request.GetDataHandle().value_or(std::string()));
           if (cachedData) {
             std::thread([=] {
-              LOG_INFO_F(kLogTag, "cache data '%s' found!", key.c_str());
+              EDGE_SDK_LOG_INFO_F(kLogTag, "cache data '%s' found!",
+                                  key.c_str());
               callback(*cachedData);
             })
                 .detach();
             return CancellationToken();
           } else if (CacheOnly == request.GetFetchOption()) {
             std::thread([=] {
-              LOG_INFO_F(kLogTag, "cache catalog '%s' not found!", key.c_str());
+              EDGE_SDK_LOG_INFO_F(kLogTag, "cache catalog '%s' not found!",
+                                  key.c_str());
               callback(
                   ApiError(ErrorCode::NotFound,
                            "Cache only resource not found in cache (data)."));
@@ -127,16 +129,17 @@ void GetDataInternal(std::shared_ptr<CancellationContext> cancellationContext,
         return apiRepo->getApiClient(
             service, "v1", [=](ApiClientResponse response) {
               if (!response.IsSuccessful()) {
-                LOG_INFO_F(kLogTag, "getApiClient '%s' unsuccessful",
-                           key.c_str());
+                EDGE_SDK_LOG_INFO_F(kLogTag, "getApiClient '%s' unsuccessful",
+                                    key.c_str());
                 callback(response.GetError());
                 return;
               }
 
               cancellationContext->ExecuteOrCancelled(
                   [=]() {
-                    LOG_INFO_F(kLogTag, "getApiClient '%s' getting catalog",
-                               key.c_str());
+                    EDGE_SDK_LOG_INFO_F(kLogTag,
+                                        "getApiClient '%s' getting catalog",
+                                        key.c_str());
                     return dataFunc(response.GetResult());
                   },
                   cancel_callback);
@@ -174,9 +177,9 @@ CancellationToken DataRepository::GetData(
     const read::DataRequest& request,
     const read::DataResponseCallback& callback) {
   auto key = request.CreateKey();
-  LOG_TRACE_F(kLogTag, "GetData '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetData '%s'", key.c_str());
   if (!request.GetDataHandle() && !request.GetPartitionId()) {
-    LOG_INFO_F(kLogTag, "getData for '%s' failed", key.c_str());
+    EDGE_SDK_LOG_INFO_F(kLogTag, "getData for '%s' failed", key.c_str());
     callback(ApiError(client::ErrorCode::InvalidArgument,
                       "A data handle or a partition id must be defined."));
     return CancellationToken();
@@ -193,7 +196,7 @@ CancellationToken DataRepository::GetData(
 
   auto cancel_context = std::make_shared<CancellationContext>();
   auto cancel_callback = [callback, key]() {
-    LOG_INFO_F(kLogTag, "cancelled '%s'", key.c_str());
+    EDGE_SDK_LOG_INFO_F(kLogTag, "cancelled '%s'", key.c_str());
     callback({{ErrorCode::Cancelled, "Operation cancelled.", true}});
   };
 
@@ -205,8 +208,8 @@ CancellationToken DataRepository::GetData(
                   catalogRequest,
                   [=, &cache](read::CatalogResponse catalogResponse) {
                     if (!catalogResponse.IsSuccessful()) {
-                      LOG_INFO_F(kLogTag, "getCatalog '%s' unsuccessful",
-                                 key.c_str());
+                      EDGE_SDK_LOG_INFO_F(
+                          kLogTag, "getCatalog '%s' unsuccessful", key.c_str());
                       callback(catalogResponse.GetError());
                       return;
                     }
@@ -220,8 +223,9 @@ CancellationToken DataRepository::GetData(
                         });
 
                     if (itr == catalogLayers.end()) {
-                      LOG_INFO_F(kLogTag, "Layer for '%s' doesn't exiist",
-                                 key.c_str());
+                      EDGE_SDK_LOG_INFO_F(kLogTag,
+                                          "Layer for '%s' doesn't exiist",
+                                          key.c_str());
                       callback(ApiError(client::ErrorCode::InvalidArgument,
                                         "Layer specified doesn't exist."));
                       return;
@@ -287,8 +291,9 @@ CancellationToken DataRepository::GetData(
                           // Backend returns an empty partition list if the
                           // partition doesn't exist in the layer. So return no
                           // data.
-                          LOG_INFO_F(kLogTag, "Empty partition for '%s'!",
-                                     key.c_str());
+                          EDGE_SDK_LOG_INFO_F(kLogTag,
+                                              "Empty partition for '%s'!",
+                                              key.c_str());
                           callback(model::Data());
                         }
                       };
@@ -318,8 +323,7 @@ CancellationToken DataRepository::GetData(
         return CancellationToken(
             [cancel_context]() { cancel_context->CancelOperation(); });
       };
-  return multiRequestContext_->ExecuteOrAssociate(key, executeFn,
-                                                  callback);
+  return multiRequestContext_->ExecuteOrAssociate(key, executeFn, callback);
 }
 
 void DataRepository::GetData(

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -66,14 +66,14 @@ void PartitionsCacheRepository::Put(const PartitionsRequest& request,
                                     const boost::optional<time_t>& expiry,
                                     bool allLayer) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  LOG_TRACE_F(kLogTag, "Put '%s'", hrn.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", hrn.c_str());
   std::vector<std::string> partitionIds;
   time_t no_expiry = std::numeric_limits<time_t>::max();
 
   for (auto partition : partitions.GetPartitions()) {
     auto key = CreateKey(hrn, request.GetLayerId(), partition.GetPartition(),
                          request.GetVersion());
-    LOG_INFO_F(kLogTag, "Put '%s'", key.c_str());
+    EDGE_SDK_LOG_INFO_F(kLogTag, "Put '%s'", key.c_str());
     cache_->Put(key, partition,
                 [=]() { return olp::serializer::serialize(partition); },
                 expiry.get_value_or(no_expiry));
@@ -83,7 +83,7 @@ void PartitionsCacheRepository::Put(const PartitionsRequest& request,
   }
   if (allLayer) {
     auto key = CreateKey(hrn, request.GetLayerId(), request.GetVersion());
-    LOG_INFO_F(kLogTag, "Put '%s'", key.c_str());
+    EDGE_SDK_LOG_INFO_F(kLogTag, "Put '%s'", key.c_str());
     cache_->Put(key, partitionIds,
                 [=]() { return olp::serializer::serialize(partitionIds); },
                 expiry.get_value_or(no_expiry));
@@ -94,13 +94,13 @@ model::Partitions PartitionsCacheRepository::Get(
     const PartitionsRequest& request,
     const std::vector<std::string>& partitionIds) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  LOG_TRACE_F(kLogTag, "Get '%s'", hrn.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", hrn.c_str());
   model::Partitions cachedPartitionsModel;
   std::vector<model::Partition> cachedPartitions;
   for (auto partitionId : partitionIds) {
     auto key =
         CreateKey(hrn, request.GetLayerId(), partitionId, request.GetVersion());
-    LOG_INFO_F(kLogTag, "Get '%s'", key.c_str());
+    EDGE_SDK_LOG_INFO_F(kLogTag, "Get '%s'", key.c_str());
     auto cachedPartition =
         cache_->Get(key, [](const std::string& serializedObject) {
           return parser::parse<model::Partition>(serializedObject);
@@ -118,7 +118,7 @@ boost::optional<model::Partitions> PartitionsCacheRepository::Get(
     const PartitionsRequest& request) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, request.GetLayerId(), request.GetVersion());
-  LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
   auto cachedIds = cache_->Get(key, [](const std::string& serializedIds) {
     return parser::parse<std::vector<std::string>>(serializedIds);
   });
@@ -132,7 +132,7 @@ boost::optional<model::Partitions> PartitionsCacheRepository::Get(
 void PartitionsCacheRepository::Put(int64_t catalogVersion,
                                     const model::LayerVersions& layerVersions) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  LOG_TRACE_F(kLogTag, "Put '%s'", hrn.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", hrn.c_str());
   cache_->Put(CreateKey(hrn, catalogVersion), layerVersions,
               [=]() { return olp::serializer::serialize(layerVersions); });
 }
@@ -141,7 +141,7 @@ boost::optional<model::LayerVersions> PartitionsCacheRepository::Get(
     int64_t catalogVersion) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, catalogVersion);
-  LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
   auto cachedLayerVersions =
       cache_->Get(key, [](const std::string& serializedObject) {
         return parser::parse<model::LayerVersions>(serializedObject);
@@ -155,7 +155,7 @@ boost::optional<model::LayerVersions> PartitionsCacheRepository::Get(
 void PartitionsCacheRepository::Clear(const std::string& layer_id) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, boost::none);
-  LOG_TRACE_F(kLogTag, "Clear '%s'", key.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Clear '%s'", key.c_str());
   cache_->RemoveKeysWithPrefix(key);
 }
 
@@ -163,7 +163,7 @@ void PartitionsCacheRepository::ClearPartitions(
     const PartitionsRequest& request,
     const std::vector<std::string>& partitionIds) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  LOG_TRACE_F(kLogTag, "ClearPartitions '%s'", hrn.c_str());
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "ClearPartitions '%s'", hrn.c_str());
   auto cachedPartitions = Get(request, partitionIds);
   // Partitions not processed here are not cached to begin with.
   for (auto partition : cachedPartitions.GetPartitions()) {

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -180,12 +180,13 @@ void PrefetchTilesRepository::GetSubQuads(
     const PrefetchTilesRequest& prefetchRequest, geo::TileKey tile,
     int64_t version, boost::optional<time_t> expiry, int32_t depth,
     const SubQuadsResponseCallback& callback) {
-  LOG_TRACE_F(kLogTag, "GetSubQuads(%s, %" PRId64 ", %" PRId32 ")",
-              tile.ToHereTile().c_str(), version, depth);
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "GetSubQuads(%s, %" PRId64 ", %" PRId32 ")",
+                       tile.ToHereTile().c_str(), version, depth);
 
   auto cancel_callback = [callback, tile, version, depth]() {
-    LOG_INFO_F(kLogTag, "GetSubQuads cancelled(%s, %" PRId64 ", %" PRId32 ")",
-               tile.ToHereTile().c_str(), version, depth);
+    EDGE_SDK_LOG_INFO_F(kLogTag,
+                        "GetSubQuads cancelled(%s, %" PRId64 ", %" PRId32 ")",
+                        tile.ToHereTile().c_str(), version, depth);
     callback({{ErrorCode::Cancelled, "Operation cancelled.", true}});
   };
 
@@ -202,8 +203,10 @@ void PrefetchTilesRepository::GetSubQuads(
 
               cancel_context->ExecuteOrCancelled(
                   [=, &partitionsCache]() {
-                    LOG_INFO_F(kLogTag, "QuadTreeIndex execute(%s, %" PRId64 ", %" PRId32 ")",
-                                tile.ToHereTile().c_str(), version, depth);
+                    EDGE_SDK_LOG_INFO_F(
+                        kLogTag,
+                        "QuadTreeIndex execute(%s, %" PRId64 ", %" PRId32 ")",
+                        tile.ToHereTile().c_str(), version, depth);
                     return QueryApi::QuadTreeIndex(
                         response.GetResult(), prefetchRequest.GetLayerId(),
                         version, tile_key, depth, boost::none,
@@ -211,13 +214,16 @@ void PrefetchTilesRepository::GetSubQuads(
                         [=, &partitionsCache](
                             QueryApi::QuadTreeIndexResponse indexResponse) {
                           if (!indexResponse.IsSuccessful()) {
-                            LOG_INFO_F(kLogTag, "QuadTreeIndex Error(%s, %" PRId64 ", %" PRId32 ")",
-                                       tile.ToHereTile().c_str(), version, depth);
+                            EDGE_SDK_LOG_INFO_F(
+                                kLogTag,
+                                "QuadTreeIndex Error(%s, %" PRId64 ", %" PRId32
+                                ")",
+                                tile.ToHereTile().c_str(), version, depth);
                             callback(indexResponse.GetError());
                             return;
                           }
 
-                          LOG_INFO(kLogTag, "QuadTreeIndex Success");
+                          EDGE_SDK_LOG_INFO(kLogTag, "QuadTreeIndex Success");
                           SubQuadsResult result;
                           model::Partitions partitions;
                           for (auto subquad :

--- a/olp-cpp-sdk-dataservice-read/test/unit/src/CatalogClientTest.cpp
+++ b/olp-cpp-sdk-dataservice-read/test/unit/src/CatalogClientTest.cpp
@@ -2204,24 +2204,26 @@ TEST_P(CatalogClientMockTest, GetCatalogCacheWithUpdate) {
   auto request = CatalogRequest();
   request.WithFetchOption(CacheWithUpdate);
   // Request 1
-  LOG_TRACE_F("CatalogClientMockTest", "Request Catalog, CacheWithUpdate");
+  EDGE_SDK_LOG_TRACE_F("CatalogClientMockTest",
+                       "Request Catalog, CacheWithUpdate");
   auto future = catalogClient->GetCatalog(request);
 
-  LOG_TRACE_F("CatalogClientMockTest", "get CatalogResponse1");
+  EDGE_SDK_LOG_TRACE_F("CatalogClientMockTest", "get CatalogResponse1");
   CatalogResponse catalogResponse = future.GetFuture().get();
 
   // Request 1 return. Cached value (nothing)
   ASSERT_FALSE(catalogResponse.IsSuccessful())
       << PrintError(catalogResponse.GetError());
   // Wait for background cache update to finish
-  LOG_TRACE_F("CatalogClientMockTest", "wait some time for update to conclude");
+  EDGE_SDK_LOG_TRACE_F("CatalogClientMockTest",
+                       "wait some time for update to conclude");
   waitForEnd->get_future().get();
 
   // Request 2 to check there is a cached value.
-  LOG_TRACE_F("CatalogClientMockTest", "Request Catalog, CacheOnly");
+  EDGE_SDK_LOG_TRACE_F("CatalogClientMockTest", "Request Catalog, CacheOnly");
   request.WithFetchOption(CacheOnly);
   future = catalogClient->GetCatalog(request);
-  LOG_TRACE_F("CatalogClientMockTest", "get CatalogResponse2");
+  EDGE_SDK_LOG_TRACE_F("CatalogClientMockTest", "get CatalogResponse2");
   catalogResponse = future.GetFuture().get();
   // Cache should be available here.
   ASSERT_TRUE(catalogResponse.IsSuccessful())


### PR DESCRIPTION
All instances of loggging macros usage in olp-cpp-sdk-dataservice-read
now utilize ones with EDGE_SDK prefix.

Relates-to: OLPEDGE-407

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>