### PR TITLE
Logging prefix for 'authentication' subproject

### DIFF
--- a/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
+++ b/olp-cpp-sdk-authentication/src/TokenEndpoint.cpp
@@ -45,13 +45,13 @@ struct TokenEndpoint::Impl {
       auto success = auth_client_.SetNetworkProxySettings(
           settings.network_proxy_settings.get());
       if (!success) {
-        LOG_WARNING(LOG_TAG, "Invalid NetworkProxySettings provided.");
+        EDGE_SDK_LOG_WARNING(LOG_TAG, "Invalid NetworkProxySettings provided.");
       }
     }
   }
 
   client::CancellationToken RequestToken(const TokenRequest& token_request,
-                                 const RequestTokenCallback& callback) {
+                                         const RequestTokenCallback& callback) {
     return auth_client_.SignInClient(
         auth_credentials_,
         [callback](
@@ -69,15 +69,17 @@ struct TokenEndpoint::Impl {
         token_request.GetExpiresIn());
   }
 
-  std::future<TokenResponse> RequestToken(client::CancellationToken& cancellation_token,
-                                          const TokenRequest& token_request);
+  std::future<TokenResponse> RequestToken(
+      client::CancellationToken& cancellation_token,
+      const TokenRequest& token_request);
 
   olp::authentication::AuthenticationClient auth_client_;
   olp::authentication::AuthenticationCredentials auth_credentials_;
 };  // namespace authentication
 
 std::future<TokenEndpoint::TokenResponse> TokenEndpoint::Impl::RequestToken(
-    client::CancellationToken& cancellation_token, const TokenRequest& token_request) {
+    client::CancellationToken& cancellation_token,
+    const TokenRequest& token_request) {
   auto p = std::make_shared<std::promise<TokenResponse> >();
   cancellation_token = RequestToken(
       token_request,
@@ -96,10 +98,11 @@ TokenEndpoint::TokenEndpoint(const AuthenticationCredentials& credentials,
   if (pos != std::string::npos) {
     strippedEndpointUrl.erase(pos, kOauth2TokenEndpoint.size());
   } else {
-    LOG_ERROR(LOG_TAG,
-              "Expected '/oauth2/token' endpoint in the tokenEndpointUrl. Only "
-              "standard "
-              "OAuth2 token endpoint URLs are supported.");
+    EDGE_SDK_LOG_ERROR(
+        LOG_TAG,
+        "Expected '/oauth2/token' endpoint in the tokenEndpointUrl. Only "
+        "standard "
+        "OAuth2 token endpoint URLs are supported.");
   }
 
   Settings strippedSettings = settings;

--- a/olp-cpp-sdk-authentication/test/unit/ArcGisTestUtils.cpp
+++ b/olp-cpp-sdk-authentication/test/unit/ArcGisTestUtils.cpp
@@ -104,7 +104,8 @@ bool ArcGisTestUtils::Impl::getAccessToken(ArcGisUser& user) {
   unsigned int retry = 0u;
   do {
     if (retry > 0u) {
-      LOG_WARNING(__func__, "Request retry attempted (" << retry << ")");
+      EDGE_SDK_LOG_WARNING(__func__,
+                           "Request retry attempted (" << retry << ")");
       std::this_thread::sleep_for(
           std::chrono::seconds(retry * RETRY_DELAY_SECS));
     }

--- a/olp-cpp-sdk-authentication/test/unit/AuthenticationTests.h
+++ b/olp-cpp-sdk-authentication/test/unit/AuthenticationTests.h
@@ -193,7 +193,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        LOG_WARNING(__func__, "Request retry attempted (" << retry << ")");
+        EDGE_SDK_LOG_WARNING(__func__,
+                             "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }
@@ -232,7 +233,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        LOG_WARNING(__func__, "Request retry attempted (" << retry << ")");
+        EDGE_SDK_LOG_WARNING(__func__,
+                             "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }
@@ -270,7 +272,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        LOG_WARNING(__func__, "Request retry attempted (" << retry << ")");
+        EDGE_SDK_LOG_WARNING(__func__,
+                             "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }
@@ -305,7 +308,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        LOG_WARNING(__func__, "Request retry attempted (" << retry << ")");
+        EDGE_SDK_LOG_WARNING(__func__,
+                             "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }
@@ -338,7 +342,8 @@ class AuthenticationOnlineTest : public AuthenticationBaseTest {
     unsigned int retry = 0u;
     do {
       if (retry > 0u) {
-        LOG_WARNING(__func__, "Request retry attempted (" << retry << ")");
+        EDGE_SDK_LOG_WARNING(__func__,
+                             "Request retry attempted (" << retry << ")");
         std::this_thread::sleep_for(
             std::chrono::seconds(retry * RETRY_DELAY_SECS));
       }

--- a/olp-cpp-sdk-authentication/test/unit/FacebookTestUtils.cpp
+++ b/olp-cpp-sdk-authentication/test/unit/FacebookTestUtils.cpp
@@ -122,7 +122,8 @@ bool FacebookTestUtils::Impl::createFacebookTestUser(FacebookUser& user,
   unsigned int retry = 0u;
   do {
     if (retry > 0u) {
-      LOG_WARNING(__func__, "Request retry attempted (" << retry << ")");
+      EDGE_SDK_LOG_WARNING(__func__,
+                           "Request retry attempted (" << retry << ")");
       std::this_thread::sleep_for(
           std::chrono::seconds(retry * RETRY_DELAY_SECS));
     }
@@ -171,7 +172,8 @@ bool FacebookTestUtils::Impl::deleteFacebookTestUser(string user_id) {
   unsigned int retry = 0u;
   do {
     if (retry > 0u) {
-      LOG_WARNING(__func__, "Request retry attempted (" << retry << ")");
+      EDGE_SDK_LOG_WARNING(__func__,
+                           "Request retry attempted (" << retry << ")");
       std::this_thread::sleep_for(
           std::chrono::seconds(retry * RETRY_DELAY_SECS));
     }

--- a/olp-cpp-sdk-authentication/test/unit/GoogleTestUtils.cpp
+++ b/olp-cpp-sdk-authentication/test/unit/GoogleTestUtils.cpp
@@ -113,7 +113,8 @@ bool GoogleTestUtils::Impl::getAccessToken(GoogleTestUtils::GoogleUser& user) {
   unsigned int retry = 0u;
   do {
     if (retry > 0u) {
-      LOG_WARNING(__func__, "Request retry attempted (" << retry << ")");
+      EDGE_SDK_LOG_WARNING(__func__,
+                           "Request retry attempted (" << retry << ")");
       std::this_thread::sleep_for(
           std::chrono::seconds(retry * RETRY_DELAY_SECS));
     }


### PR DESCRIPTION
All instances of loggging macros usage in olp-cpp-sdk-authentication
now utilize ones with EDGE_SDK prefix.

Relates-to: OLPEDGE-407

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>