### PR TITLE
Temporary macro substitution clean-up

### DIFF
--- a/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
+++ b/olp-cpp-sdk-authentication/include/olp/authentication/TokenProvider.h
@@ -105,11 +105,6 @@ class TokenProvider {
   TokenEndpoint::TokenResponse GetResponse() const {
     TokenEndpoint::TokenResponse resp =
         token_.GetToken(std::chrono::seconds{MinimumValidity});
-    if (!IsTokenResponseOK(resp)) {
-      // LOG_ERROR( "TokenProvider",
-      //           "User authentication failed with error: " << resp.error(
-      //           ).message );
-    }
     return resp;
   }
 

--- a/olp-cpp-sdk-core/include/olp/core/logging/Log.h
+++ b/olp-cpp-sdk-core/include/olp/core/logging/Log.h
@@ -33,18 +33,6 @@
 #include <sstream>
 #include <string>
 
-#define LOG_FUNCTION_SIGNATURE EDGE_SDK_LOG_FUNCTION_SIGNATURE  /// @deprecated
-#define LOG_FATAL EDGE_SDK_LOG_FATAL                            /// @deprecated
-#define LOG_TRACE EDGE_SDK_LOG_TRACE                            /// @deprecated
-#define LOG_TRACE_F EDGE_SDK_LOG_TRACE_F                        /// @deprecated
-#define LOG_DEBUG EDGE_SDK_LOG_DEBUG                            /// @deprecated
-#define LOG_DEBUG_F EDGE_SDK_LOG_DEBUG_F                        /// @deprecated
-#define LOG_INFO EDGE_SDK_LOG_INFO                              /// @deprecated
-#define LOG_INFO_F EDGE_SDK_LOG_INFO_F                          /// @deprecated
-#define LOG_WARNING EDGE_SDK_LOG_WARNING                        /// @deprecated
-#define LOG_ERROR EDGE_SDK_LOG_ERROR                            /// @deprecated
-#define LOG_ERROR_F EDGE_SDK_LOG_ERROR_F                        /// @deprecated
-
 /**
  * @file
  * @brief The file that provides the main interface to the logging library.


### PR DESCRIPTION
Non-prefix macros are now removed from Log.h since all changes to
various subprojects are merged.

Resolves: OLPEDGE-407

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>