### PR TITLE
Added iOS implementation of Network2 interface

### DIFF
--- a/olp-cpp-sdk-core/cmake/ios.cmake
+++ b/olp-cpp-sdk-core/cmake/ios.cmake
@@ -22,6 +22,20 @@ if(IOS)
         ${NETWORK_IOS_SOURCES}
         ${NETWORK_IOS_INTERNAL_INCLUDES}
     )
+
+    set(EDGE_SDK_HTTP_IOS_SOURCES
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPNetworkIOS.mm"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPNetworkIOS.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPNetworkConstants.mm"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPNetworkConstants.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPHttpTask.mm"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPHttpTask+Internal.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPHttpTask.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPHttpClient.mm"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPHttpClient+Internal.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPHttpClient.h"
+    )
+
     add_definitions(-DNETWORK_HAS_IOS)
 else()
     set(NETWORK_IOS_SOURCES)

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
@@ -57,8 +57,11 @@ enum class ErrorCode {
   OFFLINE_ERROR = -4,
   CANCELLED_ERROR = -5,
   AUTHENTICATION_ERROR = -6,
-  TIMEOUT_ERROR = -7,
-  UNKNOWN_ERROR = -8,
+  TIMEOUT_ERROR = -7,          /*!< The timeout interval of the request expired
+                                before request was completed. */
+  NETWORK_OVERLOAD_ERROR = -8, /*!< Reached maximum limit of active requests
+                                that network can process. */
+  UNKNOWN_ERROR = -9,          ///< Internal error, that can't be interpreted
 };
 
 /**

--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpClient+Internal.h
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpClient+Internal.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#import "OLPHttpClient.h"
+
+/**
+ * @brief Internal category, which extends OLPHttpClient with internal methods,
+ * which shouldn't be exposed as public API.
+ */
+@interface OLPHttpClient (Internal)
+
+@property(nonatomic, readonly) NSArray* activeTasks;
+
+- (NSURLSession*)urlSessionWithProxy:
+                     (const olp::http::NetworkProxySettings&)proxySettings
+                          andHeaders:(NSDictionary*)headers;
+
+- (void)registerDataTask:(NSURLSessionDataTask*)dataTask
+             forHttpTask:(OLPHttpTask*)httpTask;
+
+@end

--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.h
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#import <Foundation/Foundation.h>
+
+#include "olp/core/http/NetworkTypes.h"
+
+@class OLPHttpTask;
+
+namespace olp {
+namespace http {
+class NetworkProxySettings;
+}  // http
+}  // olp
+
+/**
+ * \brief Utility client to create and manage runnable tasks via NSURLSession.
+ */
+@interface OLPHttpClient : NSObject
+
+/// Creates a task with specific identifier with corresponding settings
+- (OLPHttpTask *)createTaskWithProxy:
+                     (const olp::http::NetworkProxySettings &)proxySettings
+                               andId:(olp::http::RequestId)identifier;
+
+/// Gets task by corresponding request id
+- (OLPHttpTask *)taskWithId:(olp::http::RequestId)identifier;
+
+/// Removes the task with corresponding request id
+- (void)removeTaskWithId:(olp::http::RequestId)identifier;
+
+/// Cancel the task with corresponding request id
+- (void)cancelTaskWithId:(olp::http::RequestId)identifier;
+
+/// Finish all tasks in progress and invalidate all URL sessions
+- (void)cleanup;
+
+@end

--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpClient.mm
@@ -1,0 +1,392 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#import "OLPHttpClient+Internal.h"
+
+#import <CommonCrypto/CommonDigest.h>
+#import <Security/Security.h>
+
+#include "olp/core/logging/Log.h"
+#include "olp/core/http/Network.h"
+#include "olp/core/http/NetworkProxySettings.h"
+
+#import "OLPHttpTask+Internal.h"
+
+namespace {
+constexpr auto kLogTag = "OLPHttpClient";
+}  // namespace
+
+@interface OLPHttpClient ()<NSURLSessionDataDelegate>
+
+@property(nonatomic) NSMutableDictionary* tasks;
+
+@property(nonatomic) NSMutableDictionary* urlSessions;
+
+@property(nonatomic, readonly) NSURLSession* sharedUrlSession;
+
+@property(nonatomic, readonly) NSMutableDictionary* idTaskMap;
+
+@end
+
+@implementation OLPHttpClient {
+  NSOperationQueue* _delegateQueue;
+}
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    EDGE_SDK_LOG_TRACE_F(kLogTag, "Created client=[%p] ", (__bridge void*)self);
+    _delegateQueue = [[NSOperationQueue alloc] init];
+    _delegateQueue.name = @"com.here.olp.network.HttpClientSessionQueue";
+
+    _sharedUrlSession =
+        [self urlSessionWithProxy:olp::http::NetworkProxySettings()
+                       andHeaders:nil];
+
+    _tasks = [[NSMutableDictionary alloc] init];
+    _idTaskMap = [[NSMutableDictionary alloc] init];
+    _urlSessions = [[NSMutableDictionary alloc] init];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "destroyed client=[%p] ", (__bridge void*)self);
+  if (self.sharedUrlSession) {
+    [self cleanup];
+  }
+}
+
+- (void)cleanup {
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "cleanup tasks for client=[%p]",
+                       (__bridge void*)self);
+
+  [self.sharedUrlSession finishTasksAndInvalidate];
+  [self.urlSessions
+      enumerateKeysAndObjectsUsingBlock:^(id key, id object, BOOL* stop) {
+        NSURLSession* session = object;
+        [session finishTasksAndInvalidate];
+      }];
+  [_delegateQueue cancelAllOperations];
+  _sharedUrlSession = nil;
+  [self.urlSessions removeAllObjects];
+}
+
+- (NSArray*)activeTasks {
+  NSArray* tasks = nil;
+  @synchronized(_tasks) {
+    tasks = [NSArray arrayWithArray:_tasks.allValues];
+  }
+  return tasks;
+}
+
+- (OLPHttpTask*)createTaskWithProxy:
+                    (const olp::http::NetworkProxySettings&)proxySettings
+                              andId:(olp::http::RequestId)identifier {
+  NSURLSession* session = _sharedUrlSession;
+  BOOL isProxyValid = proxySettings.GetType() !=
+                          olp::http::NetworkProxySettings::Type::NONE &&
+                      !proxySettings.GetHostname().empty();
+  if (isProxyValid) {
+    session = [self urlSessionWithProxy:proxySettings andHeaders:nil];
+  }
+
+  OLPHttpTask* task = [[OLPHttpTask alloc] initWithHttpClient:self
+                                                andURLSession:session
+                                                        andId:identifier];
+
+  self.urlSessions[@(identifier)] = session;
+  @synchronized(self.tasks) {
+    self.tasks[@(identifier)] = task;
+  }
+
+  return task;
+}
+
+- (OLPHttpTask*)taskWithId:(olp::http::RequestId)identifier {
+  OLPHttpTask* task;
+  @synchronized(_tasks) {
+    task = _tasks[@(identifier)];
+  }
+  return task;
+}
+
+- (OLPHttpTask*)taskWithTaskIdentifier:(NSUInteger)taskId {
+  OLPHttpTask* task = nil;
+  @synchronized(_tasks) {
+    task = self.idTaskMap[@(taskId)];
+  }
+  return task;
+}
+
+- (void)cancelTaskWithId:(olp::http::RequestId)identifier {
+  OLPHttpTask* task = nil;
+  @synchronized(_tasks) {
+    task = _tasks[@(identifier)];
+  }
+  if (!task) {
+    EDGE_SDK_LOG_WARNING_F(
+        kLogTag, "Cancelling unknown request with id=[%llu] ", identifier);
+    return;
+  }
+
+  [task cancel];
+}
+
+- (void)removeTaskWithId:(olp::http::RequestId)identifier {
+  @synchronized(_tasks) {
+    OLPHttpTask* task = _tasks[@(identifier)];
+    if (task.dataTask) {
+      [task.dataTask cancel];
+      [self.idTaskMap removeObjectForKey:@(task.dataTask.taskIdentifier)];
+    }
+    [_tasks removeObjectForKey:@(identifier)];
+    [self.urlSessions removeObjectForKey:@(identifier)];
+  }
+}
+
+#pragma mark - NSURLSessionDataDelegate
+
+- (void)URLSession:(NSURLSession*)session
+                    task:(NSURLSessionTask*)task
+    didCompleteWithError:(NSError*)error {
+  if (!self.sharedUrlSession &&
+      NSURLErrorCancelled != error.code) {  // Cleanup called and not cancelled
+    return;
+  }
+
+  @autoreleasepool {
+    OLPHttpTask* httpTask = [self taskWithTaskIdentifier:task.taskIdentifier];
+    if ([httpTask isValid]) {
+      [httpTask didCompleteWithError:error];
+      [self removeTaskWithId:httpTask.requestId];
+    }
+  }
+}
+
+- (void)URLSession:(NSURLSession*)session
+              dataTask:(NSURLSessionDataTask*)dataTask
+    didReceiveResponse:(NSURLResponse*)response
+     completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))
+                           completionHandler {
+  if (!self.sharedUrlSession) {  // Cleanup called
+    return;
+  }
+
+  @autoreleasepool {
+    OLPHttpTask* httpTask =
+        [self taskWithTaskIdentifier:dataTask.taskIdentifier];
+    if ([httpTask isValid] && ![httpTask isCancelled]) {
+      [httpTask didReceiveResponse:response];
+    }
+    completionHandler(NSURLSessionResponseAllow);
+  }
+}
+
+- (void)URLSession:(NSURLSession*)session
+          dataTask:(NSURLSessionDataTask*)dataTask
+    didReceiveData:(NSData*)data {
+  if (!self.sharedUrlSession) {  // Cleanup called
+    return;
+  }
+
+  @autoreleasepool {
+    OLPHttpTask* httpTask =
+        [self taskWithTaskIdentifier:dataTask.taskIdentifier];
+    if ([httpTask isValid] && ![httpTask isCancelled]) {
+      [httpTask didReceiveData:data];
+    }
+  }
+}
+
+- (void)URLSession:(NSURLSession*)session
+                   task:(NSURLSessionTask*)dataTask
+    didReceiveChallenge:(NSURLAuthenticationChallenge*)challenge
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition,
+                                  NSURLCredential*))completionHandler {
+  if (!self.sharedUrlSession) {  // Cleanup called
+    return;
+  }
+
+  @autoreleasepool {
+    if ([challenge.protectionSpace.authenticationMethod
+            isEqualToString:NSURLAuthenticationMethodServerTrust]) {
+      if (dataTask) {
+        OLPHttpTask* httpTask =
+            [self taskWithTaskIdentifier:dataTask.taskIdentifier];
+        if (![httpTask isValid]) {
+          return;
+        }
+        // TODO: Don't verify certificate is not implemented
+        if (![self shouldTrustProtectionSpace:challenge.protectionSpace]) {
+          completionHandler(
+              NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+          return;
+        }
+      }
+
+      NSURLCredential* credential = [NSURLCredential
+          credentialForTrust:challenge.protectionSpace.serverTrust];
+      completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+      return;
+    }
+
+    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+  }
+}
+
+- (void)URLSession:(NSURLSession*)session
+                          task:(NSURLSessionTask*)task
+    willPerformHTTPRedirection:(NSHTTPURLResponse*)response
+                    newRequest:(NSURLRequest*)request
+             completionHandler:
+                 (void (^)(NSURLRequest* _Nullable))completionHandler {
+  if (!self.sharedUrlSession) {  // Cleanup called
+    return;
+  }
+
+  NSURLRequest* originalRequest = task.originalRequest;
+  NSString* authorizationHeaderValue =
+      originalRequest.allHTTPHeaderFields[@"Authorization"];
+  EDGE_SDK_LOG_TRACE_F(
+      kLogTag,
+      "HTTPRedirection: self=[%p]; status=[%i]; originURL=[%s]; newURL=[%s]",
+      (__bridge void*)self, (int)response.statusCode,
+      originalRequest.URL.absoluteString.UTF8String,
+      request.URL.absoluteString.UTF8String);
+  NSMutableURLRequest* newRequest = [[NSMutableURLRequest alloc] init];
+  newRequest.URL = request.URL;
+  newRequest.timeoutInterval = request.timeoutInterval;
+  newRequest.cachePolicy = request.cachePolicy;
+  newRequest.networkServiceType = request.networkServiceType;
+  newRequest.HTTPMethod = request.HTTPMethod;
+  newRequest.HTTPBody = request.HTTPBody;
+  [request.allHTTPHeaderFields
+      enumerateKeysAndObjectsUsingBlock:^(id key, id object, BOOL* stop) {
+        [newRequest addValue:object forHTTPHeaderField:key];
+      }];
+
+  // NOTE: It appears that most headers are maintained during a redirect with
+  // the exception of the `Authorization` header.
+  // It appears that Apple's strips the `Authorization` header from the
+  // redirected URL request. If you need to maintain the `Authorization` header,
+  // you need to manually append it to the redirected request.
+  if (authorizationHeaderValue.length) {
+    [newRequest addValue:authorizationHeaderValue
+        forHTTPHeaderField:@"Authorization"];
+  }
+  completionHandler(newRequest);
+}
+
+// http://goo.gl/jmZ4Uv
+- (BOOL)shouldTrustProtectionSpace:(NSURLProtectionSpace*)protectionSpace {
+  if (!protectionSpace) {
+    return NO;
+  }
+
+  SecTrustRef serverTrust = protectionSpace.serverTrust;
+  if (!serverTrust) {
+    return NO;
+  }
+
+  // TODO - certificate paths are not supported!
+
+  // evaluate server trust against certificate
+  SecTrustResultType trustResult = kSecTrustResultInvalid;
+  OSStatus status = SecTrustEvaluate(serverTrust, &trustResult);
+
+  if (errSecSuccess != status) {
+    return NO;
+  }
+
+  return (trustResult == kSecTrustResultUnspecified ||
+          trustResult == kSecTrustResultProceed);
+}
+
+#pragma mark - Internal methods
+
+- (NSURLSession*)urlSessionWithProxy:
+                     (const olp::http::NetworkProxySettings&)proxySettings
+                          andHeaders:(NSDictionary*)headers {
+  NSMutableDictionary* proxyDict = nil;
+  BOOL isProxyValid = proxySettings.GetType() !=
+                          olp::http::NetworkProxySettings::Type::NONE &&
+                      !proxySettings.GetHostname().empty();
+
+  if (isProxyValid) {
+    NSString* proxyName =
+        [NSString stringWithUTF8String:proxySettings.GetHostname().c_str()];
+    if (proxyName.length) {
+      proxyDict = [[NSMutableDictionary alloc] init];
+      NSUInteger port = (NSUInteger)proxySettings.GetPort();
+      NSString* proxyType = (__bridge NSString*)kCFProxyTypeHTTPS;
+      BOOL httpProxy = YES;
+      if (olp::http::NetworkProxySettings::Type::SOCKS4 ==
+              proxySettings.GetType() ||
+          olp::http::NetworkProxySettings::Type::SOCKS5 ==
+              proxySettings.GetType() ||
+          olp::http::NetworkProxySettings::Type::SOCKS5_HOSTNAME ==
+              proxySettings.GetType()) {
+        proxyType = (__bridge NSString*)kCFProxyTypeSOCKS;
+        httpProxy = NO;
+      }
+      if (httpProxy) {
+        proxyDict[(__bridge NSString*)kCFNetworkProxiesHTTPEnable] = @(1);
+        proxyDict[(__bridge NSString*)kCFNetworkProxiesHTTPProxy] = proxyName;
+        proxyDict[(__bridge NSString*)kCFNetworkProxiesHTTPPort] = @(port);
+
+        proxyDict[@"HTTPSEnable"] = @(1);
+        proxyDict[@"HTTPSProxy"] = proxyName;
+        proxyDict[@"HTTPSPort"] = @(port);
+      } else {
+        proxyDict[(__bridge NSString*)kCFProxyTypeKey] = proxyType;
+      }
+      proxyDict[(__bridge NSString*)kCFProxyHostNameKey] = proxyName;
+      proxyDict[(__bridge NSString*)kCFProxyPortNumberKey] = @(port);
+      NSString* userName =
+          [NSString stringWithUTF8String:proxySettings.GetUsername().c_str()];
+      NSString* userPassword =
+          [NSString stringWithUTF8String:proxySettings.GetPassword().c_str()];
+      if (userName.length && userPassword.length) {
+        proxyDict[(NSString*)kCFProxyUsernameKey] = userName;
+        proxyDict[(NSString*)kCFProxyPasswordKey] = userPassword;
+      }
+    }
+  }
+
+  NSURLSessionConfiguration* config =
+      [NSURLSessionConfiguration ephemeralSessionConfiguration];
+  if (proxyDict) {
+    config.connectionProxyDictionary = proxyDict;
+  }
+  if (headers.count) {
+    config.HTTPAdditionalHeaders = headers;
+  }
+
+  return [NSURLSession sessionWithConfiguration:config
+                                       delegate:self
+                                  delegateQueue:_delegateQueue];
+}
+
+- (void)registerDataTask:(NSURLSessionDataTask*)dataTask
+             forHttpTask:(OLPHttpTask*)httpTask {
+  self.idTaskMap[@(dataTask.taskIdentifier)] = httpTask;
+}
+
+@end

--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpTask+Internal.h
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpTask+Internal.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#import "OLPHttpTask.h"
+
+#import <Foundation/Foundation.h>
+
+/**
+ @brief Internal category, which extends OLPHttpTask with internal methods,
+ which shouldn't be exposed as public API.
+ */
+@interface OLPHttpTask (Internal)
+
+- (void)didReceiveResponse:(NSURLResponse*)response;
+
+- (void)didReceiveData:(NSData*)data;
+
+- (void)didCompleteWithError:(NSError*)error;
+
+@end

--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.h
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#import <Foundation/Foundation.h>
+
+#include <memory>
+#include <mutex>
+
+#include <olp/core/http/Network.h>
+
+@class OLPHttpClient;
+
+/**
+ * @brief Enum, which represents the execution status of OLPHttpTask
+ */
+typedef NS_ENUM(NSUInteger, OLPHttpTaskStatus) {
+  OLPHttpTaskStatusOk,       ///< OLPHttpTask is correctly setup
+  OLPHttpTaskStatusNotReady  ///< request not ready
+};
+
+typedef void (^OLPHttpTaskReponseHandler)(NSHTTPURLResponse* response);
+typedef void (^OLPHttpTaskDataHandler)(NSData* data);
+typedef void (^OLPHttpTaskCompletionHandler)(NSError* error);
+
+/**
+ * @brief This class holds the response data from OLPHttpTask request.
+ */
+@interface OLPHttpTaskResponseData : NSObject
+
+@property(nonatomic) int status;
+
+@property(nonatomic) std::uint64_t count;
+
+@property(nonatomic) std::uint64_t offset;
+
+@property(nonatomic) bool rangeOut;
+
+@end
+
+/**
+ * @brief HTTP task, which is a wrapper around NSURLSession task.
+ * Performs HTTP request and return data in completion block.
+ * It supports customized HTTP header and can be cancelled.
+ */
+@interface OLPHttpTask : NSObject
+
+/// Initialize task with specific client, session and identifier
+- (instancetype)initWithHttpClient:(OLPHttpClient*)client
+                     andURLSession:(NSURLSession*)session
+                             andId:(olp::http::RequestId)identifier;
+
+// Data used for customizing the request
+@property(nonatomic, copy) NSString* url;
+
+@property(nonatomic, copy) NSString* HTTPMethod;
+
+@property(nonatomic) NSData* body;
+
+@property(nonatomic) NSDictionary* headers;
+
+@property(nonatomic) NSUInteger connectionTimeout;
+
+@property(nonatomic) std::shared_ptr<std::ostream> payload;
+
+// Readonly
+@property(nonatomic, readonly) olp::http::RequestId requestId;
+
+@property(nonatomic, readonly) NSURLSessionDataTask* dataTask;
+
+// Callbacks
+@property(nonatomic) olp::http::Network::Callback callback;
+
+@property(nonatomic) std::shared_ptr<std::mutex> callbackMutex;
+
+@property(nonatomic, copy) OLPHttpTaskReponseHandler responseHandler;
+
+@property(nonatomic, copy) OLPHttpTaskDataHandler dataHandler;
+
+@property(nonatomic, copy) OLPHttpTaskCompletionHandler completionHandler;
+
+// Execution flow of task
+- (OLPHttpTaskStatus)run;
+
+- (BOOL)cancel;
+
+// Inquiry
+- (BOOL)isCancelled;
+
+- (BOOL)isValid;
+
+/**
+ * Property, which holds response data of this task. If no data is received,
+ * or task is not valid anymore, it will store nil.
+ */
+@property(atomic) OLPHttpTaskResponseData* responseData;
+
+@end

--- a/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPHttpTask.mm
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#import "OLPHttpTask+Internal.h"
+
+#include "olp/core/logging/Log.h"
+
+#import "OLPHttpClient+Internal.h"
+#import "OLPNetworkConstants.h"
+
+namespace {
+constexpr auto kLogTag = "OLPHttpTask";
+}  // namespace
+
+#pragma mark - OLPHttpTaskResponseData
+
+@implementation OLPHttpTaskResponseData
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    _status = 0;
+    _count = 0;
+    _offset = 0;
+    _rangeOut = false;
+  }
+  return self;
+}
+@end
+
+#pragma mark - OLPHttpTask
+
+@interface OLPHttpTask ()
+
+@property(atomic) BOOL cancelled;
+
+@end
+
+@implementation OLPHttpTask {
+  __weak NSURLSession* _urlSession;
+  __weak OLPHttpClient* _httpClient;
+}
+
+- (instancetype)initWithHttpClient:(OLPHttpClient*)client
+                     andURLSession:(NSURLSession*)session
+                             andId:(olp::http::RequestId)identifier {
+  self = [super init];
+  if (self) {
+    _httpClient = client;
+    _HTTPMethod = OLPHttpMethodGet;
+    _urlSession = session;
+    _requestId = identifier;
+  }
+  return self;
+}
+
+- (OLPHttpTaskStatus)run {
+  if (!self.url || self.dataTask) {
+    return OLPHttpTaskStatusNotReady;
+  }
+
+  NSMutableURLRequest* request =
+      [NSMutableURLRequest requestWithURL:[NSURL URLWithString:self.url]];
+  request.timeoutInterval = self.connectionTimeout;
+  request.HTTPMethod = self.HTTPMethod;
+  if (self.body.length) {
+    request.HTTPBody = self.body;
+  }
+
+  for (NSString* key in self.headers.allKeys) {
+    NSString* value = self.headers[key];
+    [request setValue:value forHTTPHeaderField:key];
+  }
+
+  @synchronized(self) {
+    if (!self.isCancelled) {
+      _dataTask = [_urlSession dataTaskWithRequest:request];
+    }
+  }
+
+  if (!self.dataTask) {
+    return OLPHttpTaskStatusNotReady;
+  }
+
+  // Cache the task id for fast retrieve later on
+  [_httpClient registerDataTask:_dataTask forHttpTask:self];
+
+  EDGE_SDK_LOG_TRACE_F(
+      kLogTag, "Run task: id=[%llu]; task_id=[%lu];\t httpMethod=[%s];\t [%s])",
+      self.requestId, (unsigned long)self.dataTask.taskIdentifier,
+      [request.HTTPMethod UTF8String], [[self getDebugCurlString] UTF8String]);
+
+  [_dataTask resume];
+  return OLPHttpTaskStatusOk;
+}
+
+- (BOOL)cancel {
+  if (self.isCancelled) {
+    return NO;
+  }
+  EDGE_SDK_LOG_TRACE_F(kLogTag, "Cancelled task: id=[%llu]", self.requestId);
+
+  self.cancelled = YES;
+  @synchronized(self) {
+    self.responseHandler = nil;
+    self.dataHandler = nil;
+  }
+
+  if (self.dataTask) {
+    [self.dataTask cancel];
+    return YES;
+  }
+
+  return NO;
+}
+
+#pragma mark - Response handlers
+
+- (void)didCompleteWithError:(NSError*)error {
+  EDGE_SDK_LOG_TRACE_F(
+      kLogTag, "task is completed: id=[%llu]; taskIdentifier=[%u]; error=[%i]",
+      self.requestId, (unsigned int)self.dataTask.taskIdentifier,
+      (int)error.code);
+
+  OLPHttpTaskCompletionHandler completionHandler = nil;
+  @synchronized(self) {
+    if (self.completionHandler) {
+      completionHandler = [self.completionHandler copy];
+    }
+  }
+
+  if (completionHandler) {
+    completionHandler(error);
+  }
+
+  @synchronized(self) {
+    self.completionHandler = nil;
+  }
+}
+
+- (void)didReceiveResponse:(NSURLResponse*)response {
+  EDGE_SDK_LOG_TRACE_F(kLogTag,
+                       "task receives response: id=[%llu]; taskIdentifier=[%u] "
+                       "responseCode=[%i]",
+                       self.requestId,
+                       (unsigned int)self.dataTask.taskIdentifier,
+                       (int)[(NSHTTPURLResponse*)response statusCode]);
+
+  OLPHttpTaskReponseHandler responseHandler = nil;
+
+  @synchronized(self) {
+    if (self.responseHandler) {
+      responseHandler = [self.responseHandler copy];
+    }
+  }
+
+  if (responseHandler) {
+    responseHandler((NSHTTPURLResponse*)response);
+  }
+}
+
+- (void)didReceiveData:(NSData*)data {
+  EDGE_SDK_LOG_TRACE_F(
+      kLogTag,
+      "task receives data: id=[%llu]; taskIdentifier=[%u] dataLength=[%lu]",
+      self.requestId, (unsigned int)self.dataTask.taskIdentifier,
+      (unsigned long)data.length);
+
+  OLPHttpTaskDataHandler dataHandler = nil;
+
+  @synchronized(self) {
+    if (self.dataHandler) {
+      dataHandler = [self.dataHandler copy];
+    }
+  }
+
+  if (dataHandler) {
+    dataHandler(data);
+  }
+}
+
+#pragma mark - Inquiry methods
+
+- (BOOL)isValid {
+  return _urlSession != nil;
+}
+
+- (BOOL)isCancelled {
+  return self.cancelled;
+}
+
+#pragma mark - Private methods
+
+- (NSString*)getDebugCurlString {
+  NSMutableString* debugHeaders = [[NSMutableString alloc] init];
+
+  for (NSString* key in self.headers) {
+    [debugHeaders appendFormat:@"%@\"%@:%@\"", @" --header ", key,
+                               [self.headers objectForKey:key]];
+  }
+
+  return
+      [NSString stringWithFormat:@"curl -vvv \"%@\"%@", self.url, debugHeaders];
+}
+
+@end
+

--- a/olp-cpp-sdk-core/src/http/ios/OLPNetworkConstants.h
+++ b/olp-cpp-sdk-core/src/http/ios/OLPNetworkConstants.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT NSString* const OLPHttpMethodGet;
+FOUNDATION_EXPORT NSString* const OLPHttpMethodPost;
+FOUNDATION_EXPORT NSString* const OLPHttpMethodHead;
+FOUNDATION_EXPORT NSString* const OLPHttpMethodPut;
+FOUNDATION_EXPORT NSString* const OLPHttpMethodDelete;
+FOUNDATION_EXPORT NSString* const OLPHttpMethodPatch;

--- a/olp-cpp-sdk-core/src/http/ios/OLPNetworkConstants.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPNetworkConstants.mm
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#import "OLPNetworkConstants.h"
+
+NSString* const OLPHttpMethodGet = @"GET";
+NSString* const OLPHttpMethodPost = @"POST";
+NSString* const OLPHttpMethodHead = @"HEAD";
+NSString* const OLPHttpMethodPut = @"PUT";
+NSString* const OLPHttpMethodDelete = @"DELETE";
+NSString* const OLPHttpMethodPatch = @"PATCH";

--- a/olp-cpp-sdk-core/src/http/ios/OLPNetworkIOS.h
+++ b/olp-cpp-sdk-core/src/http/ios/OLPNetworkIOS.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <mutex>
+
+#include "olp/core/http/Network.h"
+
+#ifdef __OBJC__
+@class OLPHttpClient;
+using OLPHttpClientPtr = OLPHttpClient*;
+#else
+using OLPHttpClientPtr = void*;
+#endif
+
+namespace olp {
+namespace http {
+
+/**
+ * @brief The implementation of http interface on iOS using NSURLSession
+ */
+class OLPNetworkIOS : public olp::http::Network {
+ public:
+  explicit OLPNetworkIOS(size_t max_requests_count);
+  ~OLPNetworkIOS();
+
+  olp::http::SendOutcome Send(
+      olp::http::NetworkRequest request,
+      std::shared_ptr<std::ostream> payload,
+      olp::http::Network::Callback callback,
+      olp::http::Network::HeaderCallback header_callback = nullptr,
+      olp::http::Network::DataCallback data_callback = nullptr) override;
+
+  void Cancel(olp::http::RequestId identifier) override;
+
+ private:
+  void Cleanup();
+
+  olp::http::RequestId GenerateNextRequestId();
+
+ private:
+  const size_t max_requests_count_;
+  OLPHttpClientPtr http_client_{nullptr};
+  std::mutex mutex_;
+  RequestId request_id_counter_{
+      static_cast<RequestId>(RequestIdConstants::RequestIdMin)};
+};
+}  // namespace http
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/http/ios/OLPNetworkIOS.mm
+++ b/olp-cpp-sdk-core/src/http/ios/OLPNetworkIOS.mm
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#import "OLPNetworkIOS.h"
+
+#import <Foundation/Foundation.h>
+
+#include "olp/core/logging/Log.h"
+#include "olp/core/http/Network.h"
+#include "olp/core/http/NetworkTypes.h"
+
+#import "OLPHttpClient+Internal.h"
+#import "OLPHttpTask.h"
+#import "OLPNetworkConstants.h"
+
+namespace olp {
+namespace http {
+
+namespace {
+
+constexpr auto kInvalidRequestId =
+    static_cast<RequestId>(RequestIdConstants::RequestIdInvalid);
+
+constexpr auto kLogTag = "OLPNetworkIOS";
+
+NSMutableDictionary* ParseHeadersDictionaryFromRequest(
+    const olp::http::NetworkRequest& request) {
+  NSMutableDictionary* headers = [[NSMutableDictionary alloc] init];
+
+  const auto& request_headers = request.GetHeaders();
+  for (const auto& header : request_headers) {
+    NSString* key = [NSString stringWithUTF8String:header.first.c_str()];
+    NSString* value = [NSString stringWithUTF8String:header.second.c_str()];
+    headers[key] = value;
+  }
+  return headers;
+}
+
+NSData* ParseBodyDataFromRequest(const olp::http::NetworkRequest& request) {
+  const auto verb = request.GetVerb();
+  if (verb == NetworkRequest::HttpVerb::GET ||
+      verb == NetworkRequest::HttpVerb::HEAD) {
+    return nil;
+  }
+
+  const auto body = request.GetBody();
+  if (!body || body->empty()) {
+    return nil;
+  }
+  return [NSData dataWithBytes:static_cast<const void*>(body->data())
+                        length:body->size()];
+}
+
+NSString* ParseHttpMethodFromRequest(
+    const olp::http::NetworkRequest& request) {
+  switch (request.GetVerb()) {
+    case NetworkRequest::HttpVerb::GET:
+      return OLPHttpMethodGet;
+    case NetworkRequest::HttpVerb::POST:
+      return OLPHttpMethodPost;
+    case NetworkRequest::HttpVerb::PUT:
+      return OLPHttpMethodPut;
+    case NetworkRequest::HttpVerb::DEL:
+      return OLPHttpMethodDelete;
+    case NetworkRequest::HttpVerb::PATCH:
+      return OLPHttpMethodPatch;
+    case NetworkRequest::HttpVerb::HEAD:
+      return OLPHttpMethodHead;
+    default:
+      return nil;
+  }
+}
+
+olp::http::ErrorCode ConvertNSURLErrorToNetworkErrorCode(
+    NSInteger error_code) {
+  switch (error_code) {
+    case NSURLErrorUnsupportedURL:
+    case NSURLErrorCannotFindHost:
+      return ErrorCode::INVALID_URL_ERROR;
+    case NSURLErrorNotConnectedToInternet:
+      return ErrorCode::OFFLINE_ERROR;
+    case NSURLErrorTimedOut:
+      return ErrorCode::TIMEOUT_ERROR;
+    default:
+      if (error_code >= NSURLErrorClientCertificateRequired &&
+          error_code <= NSURLErrorSecureConnectionFailed) {
+        return ErrorCode::AUTHORIZATION_ERROR;
+      } else {
+        return ErrorCode::UNKNOWN_ERROR;
+      }
+      break;
+  }
+}
+}  // namespace
+
+#pragma mark - OLPNetworkIOS implementation
+
+OLPNetworkIOS::OLPNetworkIOS(size_t max_requests_count)
+    : max_requests_count_(max_requests_count) {
+  @autoreleasepool {
+    http_client_ = [[OLPHttpClient alloc] init];
+  }
+}
+
+OLPNetworkIOS::~OLPNetworkIOS() { Cleanup(); }
+
+olp::http::SendOutcome OLPNetworkIOS::Send(
+    olp::http::NetworkRequest request,
+    std::shared_ptr<std::ostream> payload,
+    olp::http::Network::Callback callback,
+    olp::http::Network::HeaderCallback header_callback,
+    olp::http::Network::DataCallback data_callback) {
+  @autoreleasepool {
+    OLPHttpTask* task = nil;
+    NSString* url = [NSString stringWithUTF8String:request.GetUrl().c_str()];
+    if (url.length == 0) {
+      EDGE_SDK_LOG_WARNING(kLogTag, "Invalid request URL");
+      return SendOutcome(ErrorCode::INVALID_URL_ERROR);
+    }
+
+    // create new OLPHttpTask, if possible
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (http_client_.activeTasks.count >= max_requests_count_) {
+        EDGE_SDK_LOG_WARNING_F(kLogTag,
+                               "Can't send request - reached max requests "
+                               "count:[%lu / %lu], URL:[%s]",
+                               http_client_.activeTasks.count,
+                               max_requests_count_, request.GetUrl().c_str());
+        return SendOutcome(ErrorCode::NETWORK_OVERLOAD_ERROR);
+      }
+
+      olp::http::RequestId request_id = GenerateNextRequestId();
+      const NetworkProxySettings& proxy_settings =
+          request.GetSettings().GetProxySettings();
+      task = [http_client_ createTaskWithProxy:proxy_settings andId:request_id];
+    }
+    if (!task) {
+      EDGE_SDK_LOG_WARNING_F(kLogTag, "Can't create task for request URL=[%s]",
+                             request.GetUrl().c_str());
+      return SendOutcome(ErrorCode::UNKNOWN_ERROR);
+    }
+
+    // Setup task request data:
+    const NetworkSettings& settings = request.GetSettings();
+
+    task.url = url;
+    task.connectionTimeout = settings.GetConnectionTimeout();
+    task.payload = payload;
+    task.callback = callback;
+    task.callbackMutex = std::make_shared<std::mutex>();
+
+    task.HTTPMethod = ParseHttpMethodFromRequest(request);
+    task.body = ParseBodyDataFromRequest(request);
+    task.headers = ParseHeadersDictionaryFromRequest(request);
+    task.responseData = [[OLPHttpTaskResponseData alloc] init];
+
+    __weak OLPHttpTask* weak_task = task;
+    auto requestId = task.requestId;
+
+    // setup handler for NSURLSessionDataTask::didReceiveResponse
+    task.responseHandler = ^(NSHTTPURLResponse* response) {
+      if (!weak_task) {
+        EDGE_SDK_LOG_WARNING_F(
+            kLogTag, "Response received after task=[%llu] was deleted",
+            requestId);
+        return;
+      }
+      __strong OLPHttpTask* strong_task = weak_task;
+      strong_task.responseData.status = (int)response.statusCode;
+
+      NSDictionary* response_headers = response.allHeaderFields;
+      if (header_callback) {
+        for (NSString* key in response_headers) {
+          // Response header NSString interpret every byte like unichar
+          // (unsigned short) and
+          //    enlarge it by one zero byte.
+          // f.e 0xc2 -> 0x00c2, 0xa9 -> 0x00a9, so trim them back.
+          std::string skey;
+          for (int i = 0; i < key.length; ++i) {
+            unichar uc = [key characterAtIndex:i];
+            if ((uc >> 8))  // uc > 0xff
+              skey += (char)(uc >> 8);
+            skey += (char)uc;
+          }
+
+          NSString* value = response_headers[key];
+          std::string svalue;
+          for (int i = 0; i < value.length; ++i) {
+            unichar uc = [value characterAtIndex:i];
+            if ((uc >> 8))  // uc > 0xff
+              svalue += (char)(uc >> 8);
+            svalue += (char)uc;
+          }
+          header_callback(skey, svalue);
+        }
+      }
+    };
+
+    // setup handler for NSURLSessionDataTask::didReceiveData callback
+    task.dataHandler = ^(NSData* data) {
+      if (!weak_task) {
+        EDGE_SDK_LOG_WARNING_F(
+            kLogTag, "Data received after task=[%llu] was deleted", requestId);
+        return;
+      }
+      __strong OLPHttpTask* strong_task = weak_task;
+      OLPHttpTaskResponseData* response_data = strong_task.responseData;
+      if (response_data.rangeOut) {
+        EDGE_SDK_LOG_TRACE(kLogTag, "Datacallback out of range");
+        return;
+      }
+
+      const size_t len = data.length;
+      if (data_callback) {
+        data_callback(reinterpret_cast<uint8_t*>(const_cast<void*>(data.bytes)),
+                      response_data.offset + response_data.count, len);
+      }
+
+      if (auto payload = strong_task.payload) {
+        if (payload->tellp() != std::streampos(response_data.count)) {
+          payload->seekp(response_data.count);
+          if (payload->fail()) {
+            EDGE_SDK_LOG_WARNING(
+                kLogTag,
+                "Reception stream doesn't support setting write point");
+            payload->clear();
+          }
+        }
+
+        const char* data_ptr = reinterpret_cast<const char*>(data.bytes);
+        payload->write(data_ptr, len);
+      }
+      response_data.count += len;
+    };
+
+    // setup handler for NSURLSessionDataTask::didCompleteWithError callback
+    task.completionHandler = ^(NSError* error) {
+      if (!weak_task) {
+        EDGE_SDK_LOG_WARNING_F(
+            kLogTag, "Completion received after task=[%llu] was deleted",
+            requestId);
+        return;
+      }
+
+      __strong OLPHttpTask* strong_task = weak_task;
+      olp::http::Network::Callback callback;
+      {
+        std::lock_guard<std::mutex> callback_lock(
+            *strong_task.callbackMutex.get());
+        if (strong_task.callback) {
+          callback = strong_task.callback;
+          strong_task.callback = nullptr;
+        }
+      }
+
+      OLPHttpTaskResponseData* response_data = strong_task.responseData;
+
+      // TODO: convert error code to string
+      std::string error_str = "Success";
+      int status = static_cast<int>(error.code);
+      const bool cancelled = NSURLErrorCancelled == status;
+      if (callback) {
+        if (error && !cancelled) {
+          error_str = status < 0
+                          ? std::string(error.localizedDescription.UTF8String)
+                          : "Failure";
+          status =
+              static_cast<int>(ConvertNSURLErrorToNetworkErrorCode(error.code));
+        } else {
+          status = cancelled ? static_cast<int>(ErrorCode::CANCELLED_ERROR)
+                             : response_data.status;
+        }
+        callback(olp::http::NetworkResponse()
+                     .WithRequestId(strong_task.requestId)
+                     .WithStatus(status)
+                     .WithError(error_str)
+                     .WithCancelled(cancelled));
+      }
+
+    };
+
+    // Perform send request asycnrhonously in a NSURLSession's thread
+    OLPHttpTaskStatus ret = [task run];
+    if (OLPHttpTaskStatusOk != ret) {
+      EDGE_SDK_LOG_WARNING_F(kLogTag, "Can't run task with id=[%llu]; url=[%s]",
+                             task.requestId, request.GetUrl().c_str());
+      return SendOutcome(kInvalidRequestId);
+    }
+    return SendOutcome(task.requestId);
+  }  // autoreleasepool
+}
+
+void OLPNetworkIOS::Cleanup() {
+  if (!http_client_) {
+    return;
+  }
+
+  std::vector<std::pair<RequestId, Network::Callback> > completed_messages;
+
+  // Adding lock since accessing http_client_.activeTasks from another
+  // method in different thread might result in crash.
+  // It happens because m_httpClient is being destroyed here, whereas
+  // another thread might start waiting for locked activeTasks.
+  // Each call to http_client_.activeTasks should be surrounded with
+  // http_client_ lock guard to prevent race condition and possible crash.
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    NSArray* tasks = http_client_.activeTasks;
+    for (OLPHttpTask* task in tasks) {
+      std::lock_guard<std::mutex> callback_lock(*task.callbackMutex.get());
+      if (task.callback) {
+        completed_messages.emplace_back(task.requestId, task.callback);
+        task.callback = nullptr;
+      }
+    }
+    @autoreleasepool {
+      [http_client_ cleanup];
+    }
+
+    http_client_ = nil;
+  }
+
+  for (auto& pair : completed_messages) {
+    pair.second(NetworkResponse()
+                    .WithRequestId(pair.first)
+                    .WithStatus(static_cast<int>(ErrorCode::CANCELLED_ERROR))
+                    .WithError("Network client is destroyed"));
+  }
+}
+
+void OLPNetworkIOS::Cancel(olp::http::RequestId identifier) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  @autoreleasepool {
+    [http_client_ cancelTaskWithId:identifier];
+  }
+}
+
+olp::http::RequestId OLPNetworkIOS::GenerateNextRequestId() {
+  auto request_id = request_id_counter_++;
+  if (request_id_counter_ ==
+      static_cast<RequestId>(RequestIdConstants::RequestIdMax)) {
+    request_id_counter_ =
+        static_cast<RequestId>(RequestIdConstants::RequestIdMin);
+  }
+  return request_id;
+}
+
+}  // http
+}  // olp


### PR DESCRIPTION
Implemented the iOS port of Network2 interface based on the NSURLSession.
Basically, this implementation used previous Network1 version as a core,
however some unused functionality were removed.

Resolves: OLPEDGE-370

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>