### PR TITLE
TaskScheduler added to OlpClientSettings

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -36,6 +36,10 @@ class NetworkConfig;
 class HttpResponse;
 }  // namespace network
 
+namespace thread {
+class TaskScheduler;
+}
+
 namespace client {
 
 using NetworkAsyncCallback = std::function<void(network::HttpResponse)>;
@@ -167,6 +171,12 @@ struct OlpClientSettings {
    * @brief The network handler.
    */
   boost::optional<NetworkAsyncHandler> network_async_handler = boost::none;
+
+  /**
+   * @brief The task scheduler instance. In case of nullptr set, all request
+   * calls will be performed synchronous.
+   */
+  std::shared_ptr<thread::TaskScheduler> task_scheduler = nullptr;
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <olp/core/CoreApi.h>
+
+#include <memory>
+
+namespace olp {
+namespace thread {
+class TaskScheduler;
+}
+
+namespace client {
+/**
+ * @brief Factory that helps to fill-in OlpClientSettings structure with various
+ * default handlers.
+ */
+class CORE_API OlpClientSettingsFactory final {
+ public:
+  /**
+   * @brief Creates a TaskScheduler instance used for all delayed operations,
+   * which is defaulted to olp::thread::ThreadPoolTaskScheduler with one worker
+   * thread spawned by default.
+   * @return An instance of TaskScheduler.
+   */
+  static std::unique_ptr<thread::TaskScheduler> CreateDefaultTaskScheduler(
+      size_t thread_count = 1u);
+};
+
+}  // namespace client
+}  // namespace olp

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "olp/core/client/OlpClientSettingsFactory.h"
+
+#include <olp/core/porting/make_unique.h>
+#include <olp/core/thread/TaskScheduler.h>
+#include <olp/core/thread/ThreadPoolTaskScheduler.h>
+
+namespace olp {
+namespace client {
+
+std::unique_ptr<thread::TaskScheduler>
+OlpClientSettingsFactory::CreateDefaultTaskScheduler(size_t thread_count) {
+  return std::make_unique<thread::ThreadPoolTaskScheduler>(thread_count);
+}
+
+}  // namespace client
+}  // namespace olp


### PR DESCRIPTION
In order to setup OlpClientSettings user should fill-in task_scheduler
field. One of the ways to do that is so use newly introduced
TaskSchedulerFactory class.

Resolves: OLPEDGE-453

Signed-off-by: Sergii Vostrikov <ext-sergii.vostrikov@here.com>