### PR TITLE
Changed NO_ERROR to SUCCESS, because of enum macro conflict

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkTypes.h
@@ -50,7 +50,7 @@ enum class RequestIdConstants : RequestId {
  * @brief Common Network error codes.
  */
 enum class ErrorCode {
-  NO_ERROR = 0,
+  SUCCESS = 0,
   IO_ERROR = -1,
   AUTHORIZATION_ERROR = -2,
   INVALID_URL_ERROR = -3,
@@ -95,7 +95,7 @@ class SendOutcome final {
    * otherwise.
    */
   bool IsSuccessfull() const {
-    return error_code_ == ErrorCode::NO_ERROR &&
+    return error_code_ == ErrorCode::SUCCESS &&
            request_id_ != kInvalidRequestId;
   }
 
@@ -108,7 +108,7 @@ class SendOutcome final {
 
   /**
    * @brief Get error code.
-   * @return \c ErrorCode::NO_ERROR in case request was successfull, any other
+   * @return \c ErrorCode::SUCCESS in case request was successfull, any other
    * ErrorCode otherwise.
    */
   ErrorCode GetErrorCode() const { return error_code_; }
@@ -117,7 +117,7 @@ class SendOutcome final {
   /// Request ID.
   RequestId request_id_{kInvalidRequestId};
   /// Error code.
-  ErrorCode error_code_{ErrorCode::NO_ERROR};
+  ErrorCode error_code_{ErrorCode::SUCCESS};
 };
 
 }  // namespace http

--- a/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
+++ b/olp-cpp-sdk-core/src/http/curl/NetworkCurl.cpp
@@ -408,7 +408,7 @@ SendOutcome NetworkCurl::Send(NetworkRequest request,
       request, request_id, payload, std::move(header_callback),
       std::move(data_callback), std::move(callback));
 
-  if (error_status == ErrorCode::NO_ERROR) {
+  if (error_status == ErrorCode::SUCCESS) {
     return SendOutcome(request_id);
   }
 
@@ -585,7 +585,7 @@ ErrorCode NetworkCurl::SendImplementation(
     std::lock_guard<std::mutex> lock(event_mutex_);
     AddEvent(EventInfo::Type::SEND_EVENT, handle);
   }
-  return ErrorCode::NO_ERROR;  // NetworkProtocol::ErrorNone;
+  return ErrorCode::SUCCESS;  // NetworkProtocol::ErrorNone;
 }
 
 void NetworkCurl::Cancel(RequestId id) {


### PR DESCRIPTION
Changed NO_ERROR to SUCCESS, because it conflicts with define in windows.h

Relates-To: OLPEDGE-372

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>