### PR TITLE
Remove std::thread raw usage replacing it with TaskScheduler

### DIFF
--- a/examples/dataservice-read/example.cpp
+++ b/examples/dataservice-read/example.cpp
@@ -23,6 +23,7 @@
 
 #include <olp/core/client/HRN.h>
 #include <olp/core/client/OlpClientSettings.h>
+#include <olp/core/client/OlpClientSettingsFactory.h>
 #include <olp/core/logging/Log.h>
 #include <olp/core/porting/make_unique.h>
 
@@ -129,6 +130,8 @@ int RunExample() {
   // Setup OlpClientSettings and provide it to the CatalogClient.
   auto settings = std::make_shared<olp::client::OlpClientSettings>();
   settings->authentication_settings = auth_settings;
+  settings->task_scheduler = std::move(
+      olp::client::OlpClientSettingsFactory::CreateDefaultTaskScheduler(1u));
 
   // Create a CatalogClient with appropriate HRN and settings.
   auto service_client = std::make_unique<olp::dataservice::read::CatalogClient>(

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
@@ -20,14 +20,11 @@
 #pragma once
 
 #include <olp/core/CoreApi.h>
+#include <olp/core/thread/TaskScheduler.h>
 
 #include <memory>
 
 namespace olp {
-namespace thread {
-class TaskScheduler;
-}  // namespace thread
-
 namespace http {
 class Network;
 }  // namespace http

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -20,7 +20,6 @@
 #include "olp/core/client/OlpClientSettingsFactory.h"
 
 #include "olp/core/porting/make_unique.h"
-#include "olp/core/thread/TaskScheduler.h"
 #include "olp/core/thread/ThreadPoolTaskScheduler.h"
 
 #include "olp/core/http/Network.h"

--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -47,20 +47,20 @@ CatalogClientImpl::CatalogClientImpl(
       settings_(settings),
       api_client_(OlpClientFactory::Create(*settings)) {
   // create repositories, satisfying dependencies.
-  auto apiRepo = std::make_shared<ApiRepository>(hrn_, settings_, cache);
+  auto api_repo = std::make_shared<ApiRepository>(hrn_, settings_, cache);
 
-  catalog_repo_ = std::make_shared<CatalogRepository>(hrn_, apiRepo, cache);
+  catalog_repo_ = std::make_shared<CatalogRepository>(hrn_, api_repo, cache);
 
   partition_repo_ = std::make_shared<PartitionsRepository>(
-      hrn_, apiRepo, catalog_repo_, cache);
+      hrn_, api_repo, catalog_repo_, cache);
 
-  data_repo_ = std::make_shared<DataRepository>(hrn_, apiRepo, catalog_repo_,
+  data_repo_ = std::make_shared<DataRepository>(hrn_, api_repo, catalog_repo_,
                                                 partition_repo_, cache);
 
   prefetch_provider_ = std::make_shared<PrefetchTilesProvider>(
-      hrn_, apiRepo, catalog_repo_, data_repo_,
+      hrn_, api_repo, catalog_repo_, data_repo_,
       std::make_shared<PrefetchTilesRepository>(
-          hrn, apiRepo, partition_repo_->GetPartitionsCacheRepository()));
+          hrn, api_repo, partition_repo_->GetPartitionsCacheRepository()));
 
   pending_requests_ = std::make_shared<PendingRequests>();
 }

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.cpp
@@ -30,7 +30,7 @@ namespace repository {
 
 namespace {
 constexpr auto kLogTag = "ApiRepository";
-}
+} // namespace
 
 using namespace olp::client;
 
@@ -96,6 +96,10 @@ olp::client::CancellationToken ApiRepository::getApiClient(
   std::string requestKey = service + "@" + serviceVersion;
   return multiRequestContext_->ExecuteOrAssociate(requestKey, executeFn,
                                                   callback);
+}
+
+const client::OlpClientSettings* ApiRepository::GetOlpClientSettings() const {
+  return settings_ ? settings_.get() : nullptr;
 }
 
 }  // namespace repository

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.h
@@ -54,9 +54,11 @@ class ApiRepository final {
       const std::string& service, const std::string& serviceVersion,
       const ApiClientCallback& callback);
 
+  const client::OlpClientSettings* GetOlpClientSettings() const;
+
  private:
   olp::client::HRN hrn_;
-  std::shared_ptr<olp::client::OlpClientSettings> settings_;
+  std::shared_ptr<client::OlpClientSettings> settings_;
   std::shared_ptr<ApiCacheRepository> cache_;
   std::shared_ptr<MultiRequestContext<ApiClientResponse, ApiClientCallback>>
       multiRequestContext_;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/CatalogRepository.cpp
@@ -25,6 +25,7 @@
 
 #include "ApiRepository.h"
 #include "CatalogCacheRepository.h"
+#include "ExecuteOrSchedule.inl"
 #include "generated/api/ConfigApi.h"
 #include "generated/api/MetadataApi.h"
 #include "olp/dataservice/read/CatalogRequest.h"
@@ -35,78 +36,75 @@ namespace dataservice {
 namespace read {
 namespace repository {
 
-using namespace olp::client;
-
 namespace {
 constexpr auto kLogTag = "CatalogRepository";
+
 }  // namespace
 
 CatalogRepository::CatalogRepository(
-    const HRN& hrn, std::shared_ptr<ApiRepository> apiRepo,
+    const client::HRN& hrn, std::shared_ptr<ApiRepository> apiRepo,
     std::shared_ptr<cache::KeyValueCache> cache)
     : hrn_(hrn),
       apiRepo_(apiRepo),
       cache_(std::make_shared<CatalogCacheRepository>(hrn, cache)) {
-  read::CatalogResponse cancelledResponse{
+  CatalogResponse cancelledResponse{
       {olp::network::Network::ErrorCode::Cancelled, "Operation cancelled."}};
-  multiRequestContext_ = std::make_shared<MultiRequestContext<
-      read::CatalogResponse, read::CatalogResponseCallback>>(cancelledResponse);
+  multiRequestContext_ = std::make_shared<
+      MultiRequestContext<CatalogResponse, CatalogResponseCallback>>(
+      cancelledResponse);
 }
 
-CancellationToken CatalogRepository::getCatalog(
+client::CancellationToken CatalogRepository::getCatalog(
     const CatalogRequest& request, const CatalogResponseCallback& callback) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  auto cancel_context = std::make_shared<CancellationContext>();
-  auto& cache = *cache_;
+  auto cancel_context = std::make_shared<client::CancellationContext>();
+  auto& cache = cache_;
 
   auto requestKey = request.CreateKey();
   EDGE_SDK_LOG_TRACE_F(kLogTag, "getCatalog '%s'", requestKey.c_str());
 
-  MultiRequestContext<read::CatalogResponse,
-                      read::CatalogResponseCallback>::ExecuteFn executeFn =
-      [=, &cache](read::CatalogResponseCallback callback) {
+  MultiRequestContext<CatalogResponse, CatalogResponseCallback>::ExecuteFn
+      executeFn = [=](CatalogResponseCallback callback) {
         cancel_context->ExecuteOrCancelled(
-            [=, &cache]() {
+            [=]() {
               EDGE_SDK_LOG_INFO_F(kLogTag, "checking catalog '%s' cache",
                                   requestKey.c_str());
               // Check the cache
               if (OnlineOnly != request.GetFetchOption()) {
-                auto cachedCatalog = cache.Get();
+                auto cachedCatalog = cache->Get();
                 if (cachedCatalog) {
-                  std::thread([=] {
+                  ExecuteOrSchedule(apiRepo_->GetOlpClientSettings(), [=] {
                     EDGE_SDK_LOG_INFO_F(kLogTag, "cache catalog '%s' found!",
                                         requestKey.c_str());
                     callback(*cachedCatalog);
-                  })
-                      .detach();
-                  return CancellationToken();
+                  });
+                  return client::CancellationToken();
                 } else if (CacheOnly == request.GetFetchOption()) {
-                  std::thread([=] {
+                  ExecuteOrSchedule(apiRepo_->GetOlpClientSettings(), [=] {
                     EDGE_SDK_LOG_INFO_F(kLogTag,
                                         "cache catalog '%s' not found!",
                                         requestKey.c_str());
-                    callback(ApiError(
-                        ErrorCode::NotFound,
+                    callback(client::ApiError(
+                        client::ErrorCode::NotFound,
                         "Cache only resource not found in cache (catalog)."));
-                  })
-                      .detach();
-                  return CancellationToken();
+                  });
+                  return client::CancellationToken();
                 }
               }
               // Query Network
               auto cacheCatalogResponseCallback =
-                  [=, &cache](CatalogResponse response) {
+                  [=](CatalogResponse response) {
                     EDGE_SDK_LOG_INFO_F(kLogTag, "network response '%s'",
                                         requestKey.c_str());
                     if (response.IsSuccessful()) {
                       EDGE_SDK_LOG_INFO_F(kLogTag, "put '%s' to cache",
                                           requestKey.c_str());
-                      cache.Put(response.GetResult());
+                      cache->Put(response.GetResult());
                     } else {
                       if (403 == response.GetError().GetHttpStatusCode()) {
                         EDGE_SDK_LOG_INFO_F(kLogTag, "clear '%s' cache",
                                             requestKey.c_str());
-                        cache.Clear();
+                        cache->Clear();
                       }
                     }
                     callback(response);
@@ -136,7 +134,7 @@ CancellationToken CatalogRepository::getCatalog(
                           EDGE_SDK_LOG_INFO_F(kLogTag,
                                               "getApiClient '%s' cancelled",
                                               requestKey.c_str());
-                          callback({{ErrorCode::Cancelled,
+                          callback({{client::ErrorCode::Cancelled,
                                      "Operation cancelled.", true}});
                         });
                   });
@@ -145,10 +143,11 @@ CancellationToken CatalogRepository::getCatalog(
             [=]() {
               EDGE_SDK_LOG_INFO_F(kLogTag, "Cancelled '%s'",
                                   requestKey.c_str());
-              callback({{ErrorCode::Cancelled, "Operation cancelled.", true}});
+              callback({{client::ErrorCode::Cancelled, "Operation cancelled.",
+                         true}});
             });
 
-        return CancellationToken(
+        return client::CancellationToken(
             [cancel_context]() { cancel_context->CancelOperation(); });
       };
   EDGE_SDK_LOG_INFO_F(kLogTag, "ExecuteOrAssociate '%s'", requestKey.c_str());
@@ -156,55 +155,53 @@ CancellationToken CatalogRepository::getCatalog(
                                                   callback);
 }
 
-CancellationToken CatalogRepository::getLatestCatalogVersion(
+client::CancellationToken CatalogRepository::getLatestCatalogVersion(
     const CatalogVersionRequest& request,
     const CatalogVersionCallback& callback) {
-  auto cancel_context = std::make_shared<CancellationContext>();
-  auto& cache = *cache_;
+  auto cancel_context = std::make_shared<client::CancellationContext>();
+  auto &cache = cache_;
 
   auto requestKey = request.CreateKey();
   EDGE_SDK_LOG_TRACE_F(kLogTag, "getCatalogVersion '%s'", requestKey.c_str());
 
   cancel_context->ExecuteOrCancelled(
-      [=, &cache]() {
+      [=]() {
         EDGE_SDK_LOG_INFO_F(kLogTag, "checking catalog '%s' cache",
                             requestKey.c_str());
         // Check the cache if cache-only request.
         if (CacheOnly == request.GetFetchOption()) {
-          auto cachedVersion = cache.GetVersion();
+          auto cachedVersion = cache->GetVersion();
           if (cachedVersion) {
-            std::thread([=] {
+            ExecuteOrSchedule(apiRepo_->GetOlpClientSettings(), [=] {
               EDGE_SDK_LOG_INFO_F(kLogTag, "cache catalog '%s' found!",
                                   requestKey.c_str());
               callback(*cachedVersion);
-            })
-                .detach();
+            });
           } else {
-            std::thread([=] {
+            ExecuteOrSchedule(apiRepo_->GetOlpClientSettings(), [=] {
               EDGE_SDK_LOG_INFO_F(kLogTag, "cache catalog '%s' not found!",
                                   requestKey.c_str());
-              callback(ApiError(
-                  ErrorCode::NotFound,
+              callback(client::ApiError(
+                  client::ErrorCode::NotFound,
                   "Cache only resource not found in cache (catalog version)."));
-            })
-                .detach();
+            });
           }
-          return CancellationToken();
+          return client::CancellationToken();
         }
         // Network Query
         auto cacheVersionResponseCallback =
-            [=, &cache](CatalogVersionResponse response) {
+            [=](CatalogVersionResponse response) {
               EDGE_SDK_LOG_INFO_F(kLogTag, "network response '%s'",
                                   requestKey.c_str());
               if (response.IsSuccessful()) {
                 EDGE_SDK_LOG_INFO_F(kLogTag, "put '%s' to cache",
                                     requestKey.c_str());
-                cache.PutVersion(response.GetResult());
+                cache->PutVersion(response.GetResult());
               } else {
                 if (403 == response.GetError().GetHttpStatusCode()) {
                   EDGE_SDK_LOG_INFO_F(kLogTag, "clear '%s' cache",
                                       requestKey.c_str());
-                  cache.Clear();
+                  cache->Clear();
                 }
               }
               callback(response);
@@ -231,19 +228,20 @@ CancellationToken CatalogRepository::getLatestCatalogVersion(
                   [=]() {
                     EDGE_SDK_LOG_INFO_F(kLogTag, "getApiClient '%s' cancelled",
                                         requestKey.c_str());
-                    callback(
-                        {{ErrorCode::Cancelled, "Operation cancelled.", true}});
+                    callback({{client::ErrorCode::Cancelled,
+                               "Operation cancelled.", true}});
                   });
             });
       },
 
       [=]() {
         EDGE_SDK_LOG_INFO_F(kLogTag, "Cancelled '%s'", requestKey.c_str());
-        callback({{ErrorCode::Cancelled, "Operation cancelled.", true}});
+        callback(
+            {{client::ErrorCode::Cancelled, "Operation cancelled.", true}});
       });
 
   EDGE_SDK_LOG_INFO_F(kLogTag, "ExecuteOrAssociate '%s'", requestKey.c_str());
-  return CancellationToken(
+  return client::CancellationToken(
       [cancel_context]() { cancel_context->CancelOperation(); });
 }
 

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ExecuteOrSchedule.inl
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ExecuteOrSchedule.inl
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include <olp/core/thread/TaskScheduler.h>
+#include <olp/core/client/OlpClientSettings.h>
+
+namespace olp {
+namespace dataservice {
+namespace read {
+namespace repository {
+
+namespace {
+
+using client::OlpClientSettings;
+using CallFuncType = thread::TaskScheduler::CallFuncType;
+
+void ExecuteOrSchedule(const OlpClientSettings* settings, CallFuncType&& func) {
+  if (!settings || !settings->task_scheduler) {
+    // User didn't specify a TaskScheduler, execute sync
+    func();
+  } else {
+    settings->task_scheduler->ScheduleTask(std::move(func));
+  }
+}
+
+} // namespace
+
+}  // namespace repository
+}  // namespace read
+}  // namespace dataservice
+}  // namespace olp

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.cpp
@@ -17,6 +17,7 @@
  * License-Filename: LICENSE
  */
 
+#include "ExecuteOrSchedule.inl"
 #include "PrefetchTilesRepository.h"
 
 #include <olp/core/logging/Log.h>
@@ -169,8 +170,7 @@ void PrefetchTilesRepository::GetSubTiles(
     }
 
     callback({*results});
-  })
-      .detach();
+  }).detach();
 }
 
 void PrefetchTilesRepository::GetSubQuads(


### PR DESCRIPTION
Instead o fcreating detached threads use TaskScheduler to invoke
callbacks.

Based on draft PR #82.

Relates-To:OLPEDGE-456

Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>