### PR TITLE
Replaced dashes to underscores in test parameters.

### DIFF
--- a/olp-cpp-sdk-dataservice-write/test/unit/TestIndexLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/test/unit/TestIndexLayerClient.cpp
@@ -38,7 +38,7 @@ const std::string kEndpoint = "endpoint";
 const std::string kAppid = "appid";
 const std::string kSecret = "secret";
 const std::string kCatalog = "catalog";
-const std::string kIndexLayer = "index-layer";
+const std::string kIndexLayer = "index_layer";
 
 // TODO: Move duplicate test code to common header
 namespace {

--- a/olp-cpp-sdk-dataservice-write/test/unit/TestStreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/test/unit/TestStreamLayerClient.cpp
@@ -49,7 +49,7 @@ const std::string kSecret = "secret";
 const std::string kCatalog = "catalog";
 const std::string kLayer = "layer";
 const std::string kLayer2 = "layer2";
-const std::string kLayerSdii = "layer-sdii";
+const std::string kLayerSdii = "layer_sdii";
 
 // TODO: Move duplicate test code to common header
 namespace {

--- a/olp-cpp-sdk-dataservice-write/test/unit/TestVersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/test/unit/TestVersionedLayerClient.cpp
@@ -38,8 +38,8 @@ const std::string kSecret = "secret";
 const std::string kCatalog = "catalog";
 const std::string kLayer = "layer";
 const std::string kLayer2 = "layer2";
-const std::string kLayerSdii = "layer-sdii";
-const std::string kVersionedLayer = "versioned-layer";
+const std::string kLayerSdii = "layer_sdii";
+const std::string kVersionedLayer = "versioned_layer";
 
 class VersionedLayerClientTest : public ::testing::TestWithParam<bool> {};
 

--- a/olp-cpp-sdk-dataservice-write/test/unit/TestVolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/test/unit/TestVolatileLayerClient.cpp
@@ -38,7 +38,7 @@ const std::string kEndpoint = "endpoint";
 const std::string kAppid = "appid";
 const std::string kSecret = "secret";
 const std::string kCatalog = "catalog";
-const std::string kVolatileLayer = "volatile-layer";
+const std::string kVolatileLayer = "volatile_layer";
 
 // TODO: Move duplicate test code to common header
 namespace {


### PR DESCRIPTION
Change the test parameters.

Environment variables must not contain dashes.

Relates-To: OLPEDGE-486

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>