### PR TITLE
Enable offline read and write tests

### DIFF
--- a/scripts/linux/test.sh
+++ b/scripts/linux/test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -xe
 CPP_TEST_SOURCE_AUTHENTICATION=build/olp-cpp-sdk-authentication/test
 CPP_TEST_SOURCE_CORE=build/olp-cpp-sdk-core/tests
+CPP_TEST_SOURCE_DARASERVICE_READ=build/olp-cpp-sdk-dataservice-read/test
+CPP_TEST_SOURCE_DARASERVICE_WRITE=build/olp-cpp-sdk-dataservice-write/test
 echo ">>> Authentication Test ... >>>"
 $CPP_TEST_SOURCE_AUTHENTICATION/unit/olp-authentication-test --gtest_output="xml:report.xml" --gtest_filter="AuthenticationOfflineTest.*"
 echo ">>> Core - Cache Test ... >>>"
@@ -13,4 +15,8 @@ echo ">>> Core - Network Test ... >>>"
 $CPP_TEST_SOURCE_CORE/network/olp-core-network-test --gtest_output="xml:report4.xml" --gtest_filter="*Offline*:*offline*"
 echo ">>> Core - Thread Test ... >>>"
 $CPP_TEST_SOURCE_CORE/thread/thread-test --gtest_output="xml:report5.xml"
+echo ">>> Dataservice read Test ... >>>"
+$CPP_TEST_SOURCE_DARASERVICE_READ/unit/olp-dataservice-read-test --gtest_output="xml:report6.xml" --gtest_filter=-"TestOnline/*":"*GetPartitions403CacheClear*"
+echo ">>> Dataservice write Test ... >>>"
+$CPP_TEST_SOURCE_DARASERVICE_WRITE/olp-dataservice-write-test --gtest_output="xml:report7.xml" --gtest_filter=-"*Online*":"TestCacheMock*"
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Enable mocked and offline tests for linux PSV.
Some failing tests are disabled.

Relates-To: OLPEDGE-486

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>