### PR TITLE
Add factory for default network implementation

### DIFF
--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -79,6 +79,7 @@ set(EDGE_SDK_HTTP_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/http/NetworkRequest.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/http/NetworkResponse.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/http/NetworkSettings.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/http/NetworkTypes.h"
 )
 file(GLOB PLATFORM_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/context/*.h"
@@ -140,6 +141,7 @@ file(GLOB NETWORK_SOURCE
 )
 
 set(EDGE_SDK_HTTP_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/http/Network.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/http/NetworkProxySettings.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/http/NetworkRequest.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/http/NetworkResponse.cpp"
@@ -163,18 +165,26 @@ if (ANDROID)
         "${CMAKE_CURRENT_SOURCE_DIR}/src/http/android/utils/JNIScopedLocalReference.h"
     )
     set(EDGE_SDK_HTTP_SOURCES ${EDGE_SDK_HTTP_SOURCES} ${EDGE_SDK_HTTP_ANDROID_SOURCES})
+
+    set(EDGE_SDK_DEFAULT_NETWORK_DEFINITION NETWORK_HAS_ANDROID)
 endif()
 if (UNIX AND NOT ANDROID)
     set(NETWORK_SOURCE ${NETWORK_SOURCE} ${NETWORK_CURL_SOURCES})
     set(EDGE_SDK_HTTP_SOURCES ${EDGE_SDK_HTTP_SOURCES} ${EDGE_SDK_HTTP_CURL_SOURCES})
+
+    set(EDGE_SDK_DEFAULT_NETWORK_DEFINITION NETWORK_HAS_CURL)
 endif()
 if (IOS)
     set(NETWORK_SOURCE ${NETWORK_SOURCE} ${NETWORK_IOS_SOURCES})
     set(EDGE_SDK_HTTP_SOURCES ${EDGE_SDK_HTTP_SOURCES} ${EDGE_SDK_HTTP_IOS_SOURCES})
+
+    set(EDGE_SDK_DEFAULT_NETWORK_DEFINITION NETWORK_HAS_IOS)
 endif()
 if (WIN32)
     set(NETWORK_SOURCE ${NETWORK_SOURCE} ${NETWORK_WINHTTP_SOURCES})
     set(EDGE_SDK_HTTP_SOURCES ${EDGE_SDK_HTTP_SOURCES} ${EDGE_SDK_HTTP_WIN_SOURCES})
+
+    set(EDGE_SDK_DEFAULT_NETWORK_DEFINITION NETWORK_HAS_WINHTTP)
 endif()
 
 file(GLOB PLATFORM_SOURCE
@@ -234,6 +244,9 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 add_library(${PROJECT_NAME}
     ${CORE_SOURCE}
     ${CORE_HEADERS})
+
+target_compile_definitions(${PROJECT_NAME} 
+    PRIVATE ${EDGE_SDK_DEFAULT_NETWORK_DEFINITION})
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettings.h
@@ -26,6 +26,7 @@
 #include <boost/optional.hpp>
 
 #include "olp/core/client/CancellationToken.h"
+#include "olp/core/http/Network.h"
 #include "olp/core/network/NetworkProxy.h"
 
 namespace olp {
@@ -39,10 +40,6 @@ class HttpResponse;
 namespace thread {
 class TaskScheduler;
 }  // namespace thread
-
-namespace http {
-class Network;
-}  // namespace http
 
 namespace client {
 

--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
@@ -50,7 +50,8 @@ class CORE_API OlpClientSettingsFactory final {
    * which is defaulted to platform-specific implementation.
    * @return An instance of Network.
    */
-  static std::unique_ptr<http::Network> CreateDefaultNetworkRequestHandler();
+  static std::unique_ptr<http::Network> CreateDefaultNetworkRequestHandler(
+      size_t max_requests_count = 30u);
 };
 
 }  // namespace client

--- a/olp-cpp-sdk-core/include/olp/core/http/Network.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/Network.h
@@ -83,5 +83,10 @@ class CORE_API Network {
   virtual void Cancel(RequestId id) = 0;
 };
 
+/**
+ * @brief Create default Network implementation.
+ */
+CORE_API std::unique_ptr<Network> CreateDefaultNetwork(size_t max_requests_count);
+
 }  // namespace http
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -33,8 +33,8 @@ OlpClientSettingsFactory::CreateDefaultTaskScheduler(size_t thread_count) {
 }
 
 std::unique_ptr<http::Network>
-OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler() {
-  return nullptr;
+OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler(size_t max_requests_count) {
+  return http::CreateDefaultNetwork(max_requests_count);
 }
 
 }  // namespace client

--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#include "olp/core/http/Network.h"
+
+#include "olp/core/porting/make_unique.h"
+#include "olp/core/utils/WarningWorkarounds.h"
+
+#ifdef NETWORK_HAS_CURL
+#include "curl/NetworkCurl.h"
+#elif NETWORK_HAS_ANDROID
+#include "android/NetworkAndroid.h"
+#elif NETWORK_HAS_IOS
+#include "ios/OLPNetworkIOS.h"
+#elif NETWORK_HAS_WINHTTP
+#include "winhttp/NetworkWinHttp.h"
+#endif
+
+namespace olp {
+namespace http {
+
+CORE_API std::unique_ptr<Network> CreateDefaultNetwork(size_t max_requests_count) {
+#ifdef NETWORK_HAS_CURL
+  CORE_UNUSED(max_requests_count);
+  return std::make_unique<NetworkCurl>();
+#elif NETWORK_HAS_ANDROID
+  CORE_UNUSED(max_requests_count);
+  return std::make_unique<NetworkAndroid>();
+#elif NETWORK_HAS_IOS
+  return std::make_unique<OLPNetworkIOS>(max_requests_count);
+#elif NETWORK_HAS_WINHTTP
+  CORE_UNUSED(max_requests_count);
+  return std::make_unique<NetworkWinHttp>();
+#else 
+  CORE_UNUSED(max_requests_count);
+  static_assert(false, "No default network implementation provided");
+#endif
+}
+
+} // namespace http
+} // namespace olp

--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
@@ -934,6 +934,7 @@ NetworkAndroid::ResponseData::ResponseData(
       status(status),
       count(count),
       offset(offset) {}
+      
 
 }  // namespace http
 }  // namespace olp


### PR DESCRIPTION
Provide a free function that returns unique_ptr to default network
implementation.

Related-To: OLPEDGE-641

Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>