### PR TITLE
Adapt Api repository to use task scheduler instead of std::thread

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -81,8 +81,9 @@ CancellationToken CatalogClientImpl::GetCatalog(
   auto request_callback = [pending_requests, request_key,
                            callback](CatalogResponse response) {
     EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog remove key: %ld", request_key);
-    pending_requests->Remove(request_key);
-    callback(response);
+    if (pending_requests->Remove(request_key)) {
+      callback(response);
+    }
   };
   if (CacheWithUpdate == request.GetFetchOption()) {
     auto req = request;
@@ -123,8 +124,9 @@ CancellationToken CatalogClientImpl::GetCatalogMetadataVersion(
   auto request_callback = [pending_requests, request_key,
                            callback](CatalogVersionResponse response) {
     EDGE_SDK_LOG_INFO_F(kLogTag, "GetCatalog remove key: %ld", request_key);
-    pending_requests->Remove(request_key);
-    callback(response);
+    if (pending_requests->Remove(request_key)) {
+      callback(response);
+    }
   };
   if (CacheWithUpdate == request.GetFetchOption()) {
     auto req = request;
@@ -165,8 +167,9 @@ olp::client::CancellationToken CatalogClientImpl::GetPartitions(
   auto pending_requests = pending_requests_;
   auto request_callback = [pending_requests, request_key,
                            callback](PartitionsResponse response) {
-    pending_requests->Remove(request_key);
-    callback(response);
+    if (pending_requests->Remove(request_key)) {
+      callback(response);
+    }
   };
   if (CacheWithUpdate == request.GetFetchOption()) {
     auto req = request;
@@ -203,8 +206,9 @@ client::CancellationToken CatalogClientImpl::GetData(
   auto pending_requests = pending_requests_;
   auto request_callback = [pending_requests, request_key,
                            callback](DataResponse response) {
-    pending_requests->Remove(request_key);
-    callback(response);
+    if (pending_requests->Remove(request_key)) {
+      callback(response);
+    }
   };
   if (CacheWithUpdate == request.GetFetchOption()) {
     auto req = request;

--- a/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/ApiRepository.cpp
@@ -20,6 +20,7 @@
 #include "ApiRepository.h"
 #include <olp/core/client/OlpClientFactory.h>
 #include "ApiCacheRepository.h"
+#include "ExecuteOrSchedule.inl"
 
 #include <olp/core/logging/Log.h>
 
@@ -30,7 +31,7 @@ namespace repository {
 
 namespace {
 constexpr auto kLogTag = "ApiRepository";
-} // namespace
+}  // namespace
 
 using namespace olp::client;
 
@@ -61,7 +62,7 @@ olp::client::CancellationToken ApiRepository::getApiClient(
 
     auto client = olp::client::OlpClientFactory::Create(*settings_);
     client->SetBaseUrl(*url);
-    std::thread([=] { callback(*client); }).detach();
+    ExecuteOrSchedule(settings_.get(), [=] { callback(*client); });
     return CancellationToken();
   }
 


### PR DESCRIPTION
Fix double callback in catalog client.
Partition repository captures cache by shared_ptr (Fix for dangling pointer).

Resolves: OLPEDGE-633

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>