### PR TITLE
Add china URLs to read and write lookup API.

### DIFF
--- a/olp-cpp-sdk-core/src/logging/MessageFormatter.cpp
+++ b/olp-cpp-sdk-core/src/logging/MessageFormatter.cpp
@@ -89,7 +89,7 @@ MessageFormatter::Element::Element(ElementType type_) : type(type_), limit(0) {
 
 const MessageFormatter::LevelNameMap& MessageFormatter::defaultLevelNameMap() {
   static MessageFormatter::LevelNameMap defaultLevelNameMap = {
-      {"[TRACE]", "[DEBUG]", "[INFO ]", "[WARN ]", "[ERROR]", "[FATAL]"}};
+      {"[TRACE]", "[DEBUG]", "[INFO]", "[WARN]", "[ERROR]", "[FATAL]"}};
 
   return defaultLevelNameMap;
 }


### PR DESCRIPTION
To support china use cases two new URLs will be used for
here-cn and here-cn-dev partitions based on the provided HRN.
This also fixes a small bug in the logging formatter.

Relates-to: OLPEDGE-558

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>