### PR TITLE
Adapt PrefetchTilesProvider to use task scheduler.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -57,10 +57,12 @@ CatalogClientImpl::CatalogClientImpl(
   data_repo_ = std::make_shared<DataRepository>(hrn_, api_repo, catalog_repo_,
                                                 partition_repo_, cache);
 
+  auto prefetch_repo = std::make_shared<PrefetchTilesRepository>(
+      hrn, api_repo, partition_repo_->GetPartitionsCacheRepository());
+
   prefetch_provider_ = std::make_shared<PrefetchTilesProvider>(
-      hrn_, api_repo, catalog_repo_, data_repo_,
-      std::make_shared<PrefetchTilesRepository>(
-          hrn, api_repo, partition_repo_->GetPartitionsCacheRepository()));
+      hrn_, api_repo, catalog_repo_, data_repo_, std::move(prefetch_repo),
+      settings_);
 
   pending_requests_ = std::make_shared<PendingRequests>();
 }

--- a/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.h
+++ b/olp-cpp-sdk-dataservice-read/src/PrefetchTilesProvider.h
@@ -45,7 +45,8 @@ class PrefetchTilesProvider final {
       std::shared_ptr<repository::ApiRepository> apiRepo,
       std::shared_ptr<repository::CatalogRepository> catalogRepo,
       std::shared_ptr<repository::DataRepository> dataRepo,
-      std::shared_ptr<repository::PrefetchTilesRepository> prefetchTilesRepo);
+      std::shared_ptr<repository::PrefetchTilesRepository> prefetchTilesRepo,
+      std::shared_ptr<olp::client::OlpClientSettings> settings);
   /**
    * @brief pre-fetches a set of tiles asynchronously
    *
@@ -79,6 +80,7 @@ class PrefetchTilesProvider final {
   std::shared_ptr<repository::CatalogRepository> catalogRepo_;
   std::shared_ptr<repository::DataRepository> dataRepo_;
   std::shared_ptr<repository::PrefetchTilesRepository> prefetchTilesRepo_;
+  std::shared_ptr<olp::client::OlpClientSettings> settings_;
 };
 
 }  // namespace read


### PR DESCRIPTION
Adapt PrefetchTilesProvider to use task scheduler instead of std::thread.

Resolves: OLPEDGE-631

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>