### PR TITLE
Adapt PrefetchTilesRepository to use task scheduler.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/CatalogClientImpl.cpp
@@ -58,7 +58,8 @@ CatalogClientImpl::CatalogClientImpl(
                                                 partition_repo_, cache);
 
   auto prefetch_repo = std::make_shared<PrefetchTilesRepository>(
-      hrn, api_repo, partition_repo_->GetPartitionsCacheRepository());
+      hrn, api_repo, partition_repo_->GetPartitionsCacheRepository(),
+      settings_);
 
   prefetch_provider_ = std::make_shared<PrefetchTilesProvider>(
       hrn_, api_repo, catalog_repo_, data_repo_, std::move(prefetch_repo),

--- a/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PrefetchTilesRepository.h
@@ -52,7 +52,8 @@ class PrefetchTilesRepository final {
  public:
   PrefetchTilesRepository(
       const client::HRN& hrn, std::shared_ptr<ApiRepository> apiRepo,
-      std::shared_ptr<PartitionsCacheRepository> partitionsCache);
+      std::shared_ptr<PartitionsCacheRepository> partitionsCache,
+      std::shared_ptr<olp::client::OlpClientSettings> settings);
 
   ~PrefetchTilesRepository() = default;
 
@@ -100,6 +101,7 @@ class PrefetchTilesRepository final {
   client::HRN hrn_;
   std::shared_ptr<ApiRepository> apiRepo_;
   std::shared_ptr<PartitionsCacheRepository> partitionsCache_;
+  std::shared_ptr<olp::client::OlpClientSettings> settings_;
 };
 
 }  // namespace repository


### PR DESCRIPTION
Adapt PrefetchTilesRepository to use task scheduler.

For a scenario when the task scheduler not present, std::thread is used.
Else, the network thread is blocked with a waiting for promise.

Resolves: OLPEDGE-632

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>