### PR TITLE
Added the User-Agent header to http network request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,21 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-# build the sdk targets
+# Build the sdk targets
 project(olp-cpp-sdk VERSION 0.6.0)
+
+# Add preprocessor definitions for the SDK version and platform name
+add_definitions(-DEDGE_SDK_VERSION_STRING=\"${olp-cpp-sdk_VERSION}\")
+add_definitions(-DEDGE_SDK_VERSION_MAJOR=${olp-cpp-sdk_VERSION_MAJOR})
+add_definitions(-DEDGE_SDK_VERSION_MINOR=${olp-cpp-sdk_VERSION_MINOR})
+add_definitions(-DEDGE_SDK_VERSION_PATCH=${olp-cpp-sdk_VERSION_PATCH})
+
+if (APPLE AND IOS)
+    # To distinguish iOS platform from other Darwin platforms
+    add_definitions(-DEDGE_SDK_PLATFORM_NAME=\"iOS\")
+else()
+    add_definitions(-DEDGE_SDK_PLATFORM_NAME=\"${CMAKE_SYSTEM_NAME}\")
+endif()
 
 # Options
 option(EDGE_SDK_ENABLE_TESTING "Flag to enable/disable building unit and integration tests" ON)

--- a/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
+++ b/olp-cpp-sdk-authentication/src/AuthenticationClient.cpp
@@ -38,6 +38,7 @@
 #include "SignUpResultImpl.h"
 #include "olp/authentication/AuthenticationError.h"
 #include "olp/core/client/CancellationToken.h"
+#include "olp/core/http/NetworkConstants.h"
 #include "olp/core/network/HttpStatusCode.h"
 #include "olp/core/network/Network.h"
 #include "olp/core/network/NetworkRequest.h"
@@ -62,8 +63,6 @@ static const std::string PARAM_QUOTE = "\"";
 static const char LINE_FEED = '\n';
 
 // Tags
-static const std::string AUTHORIZATION = "Authorization";
-static const std::string CONTENT_TYPE = "Content-Type";
 static const std::string APPLICATION_JSON = "application/json";
 static const std::string OAUTH_POST = "POST";
 static const std::string OAUTH_CONSUMER_KEY = "oauth_consumer_key";
@@ -271,8 +270,10 @@ client::CancellationToken AuthenticationClient::Impl::SignInClient(
   url.append(OAUTH_ENDPOINT);
   NetworkRequest request(url, 0, NetworkRequest::PriorityDefault,
                          NetworkRequest::HttpVerb::POST);
-  request.AddHeader(AUTHORIZATION, generateHeader(credentials, url));
-  request.AddHeader(CONTENT_TYPE, APPLICATION_JSON);
+  request.AddHeader(http::kAuthorizationHeader,
+                    generateHeader(credentials, url));
+  request.AddHeader(http::kContentTypeHeader, APPLICATION_JSON);
+  request.AddHeader(http::kUserAgentHeader, http::kOlpSdkUserAgent);
 
   std::shared_ptr<std::stringstream> payload =
       std::make_shared<std::stringstream>();
@@ -390,8 +391,10 @@ client::CancellationToken AuthenticationClient::Impl::HandleUserRequest(
   url.append(endpoint);
   NetworkRequest request(url, 0, NetworkRequest::PriorityDefault,
                          NetworkRequest::HttpVerb::POST);
-  request.AddHeader(AUTHORIZATION, generateHeader(credentials, url));
-  request.AddHeader(CONTENT_TYPE, APPLICATION_JSON);
+  request.AddHeader(http::kAuthorizationHeader,
+                    generateHeader(credentials, url));
+  request.AddHeader(http::kContentTypeHeader, APPLICATION_JSON);
+  request.AddHeader(olp::http::kUserAgentHeader, olp::http::kOlpSdkUserAgent);
 
   std::shared_ptr<std::stringstream> payload =
       std::make_shared<std::stringstream>();
@@ -476,8 +479,10 @@ client::CancellationToken AuthenticationClient::Impl::SignUpHereUser(
   url.append(USER_ENDPOINT);
   NetworkRequest request(url, 0, NetworkRequest::PriorityDefault,
                          NetworkRequest::HttpVerb::POST);
-  request.AddHeader(AUTHORIZATION, generateHeader(credentials, url));
-  request.AddHeader(CONTENT_TYPE, APPLICATION_JSON);
+  request.AddHeader(http::kAuthorizationHeader,
+                    generateHeader(credentials, url));
+  request.AddHeader(http::kContentTypeHeader, APPLICATION_JSON);
+  request.AddHeader(http::kUserAgentHeader, http::kOlpSdkUserAgent);
 
   std::shared_ptr<std::stringstream> payload =
       std::make_shared<std::stringstream>();
@@ -519,7 +524,9 @@ client::CancellationToken AuthenticationClient::Impl::SignOut(
   url.append(SIGNOUT_ENDPOINT);
   NetworkRequest request(url, 0, NetworkRequest::PriorityDefault,
                          NetworkRequest::HttpVerb::POST);
-  request.AddHeader(AUTHORIZATION, generateBearerHeader(userAccessToken));
+  request.AddHeader(http::kAuthorizationHeader,
+                    generateBearerHeader(userAccessToken));
+  request.AddHeader(http::kUserAgentHeader, http::kOlpSdkUserAgent);
 
   std::shared_ptr<std::stringstream> payload =
       std::make_shared<std::stringstream>();
@@ -595,7 +602,7 @@ std::string AuthenticationClient::Impl::generateHeader(
 
 std::string AuthenticationClient::Impl::generateBearerHeader(
     const std::string& bearer_token) {
-  std::string authorization = "Bearer ";
+  std::string authorization = http::kBearer + std::string(" ");
   authorization += bearer_token;
   return authorization;
 }

--- a/olp-cpp-sdk-core/CMakeLists.txt
+++ b/olp-cpp-sdk-core/CMakeLists.txt
@@ -75,6 +75,7 @@ file(GLOB NETWORK_HEADERS
 )
 set(EDGE_SDK_HTTP_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/http/Network.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/http/NetworkConstants.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/http/NetworkProxySettings.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/http/NetworkRequest.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/olp/core/http/NetworkResponse.h"

--- a/olp-cpp-sdk-core/include/olp/core/http/Network.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/Network.h
@@ -29,6 +29,7 @@
 #include <olp/core/http/NetworkTypes.h>
 
 namespace olp {
+/// The HTTP namespace provides a platform specific network abstraction layer.
 namespace http {
 
 /**
@@ -36,15 +37,14 @@ namespace http {
  */
 class CORE_API Network {
  public:
-  /// Represents callback to be called when the request has been processed or
-  /// cancelled.
+  /// Callback to be called when the request has been processed or cancelled.
   using Callback = std::function<void(NetworkResponse response)>;
 
-  /// Represents callback to be called when a header has been received.
+  /// Callback to be called when a header has been received.
   using HeaderCallback =
       std::function<void(std::string key, std::string value)>;
 
-  /// Represents callback to be called when a chunk of data has been received.
+  /// Callback to be called when a chunk of data has been received.
   using DataCallback = std::function<void(
       const std::uint8_t* data, std::uint64_t offset, std::size_t length)>;
 

--- a/olp-cpp-sdk-core/include/olp/core/http/NetworkConstants.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/NetworkConstants.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace olp {
+namespace http {
+
+/**
+ * HTTP Headers
+ */
+static constexpr auto kAuthorizationHeader = "Authorization";
+static constexpr auto kContentTypeHeader = "Content-Type";
+static constexpr auto kUserAgentHeader = "User-Agent";
+
+/**
+ * Custom constants
+ */
+static constexpr auto kBearer = "Bearer";
+static constexpr auto kOlpSdkUserAgent =
+    "OLP-CPP-SDK/" EDGE_SDK_VERSION_STRING " (" EDGE_SDK_PLATFORM_NAME ")";
+
+}  // namespace http
+}  // namespace olp


### PR DESCRIPTION
Added OLP-CPP-SDK User-Agent header for all request in olp-cpp-sdk-core with next format:
	User-Agent: OLP-SDK-CPP/<Version> (<PlatformName>)

Resolves: OLPEDGE-552

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>