### PR TITLE
Fixes the cache clear key for partitions and the according test.

### DIFF
--- a/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
+++ b/olp-cpp-sdk-dataservice-read/src/repositories/PartitionsCacheRepository.cpp
@@ -40,12 +40,12 @@ std::string CreateKey(const std::string& hrn, const std::string& layerId,
                       const std::string& partitionId,
                       const boost::optional<int64_t>& version) {
   return hrn + "::" + layerId + "::" + partitionId +
-         "::" + (version ? std::to_string(*version) : "") + "::partition";
+         "::" + (version ? std::to_string(*version) + "::partition" : "");
 }
 std::string CreateKey(const std::string& hrn, const std::string& layerId,
                       const boost::optional<int64_t>& version) {
   return hrn + "::" + layerId +
-         "::" + (version ? std::to_string(*version) : "") + "::partitions";
+         "::" + (version ? std::to_string(*version) + "::partitions" : "");
 }
 std::string CreateKey(const std::string& hrn, const int64_t catalogVersion) {
   return hrn + "::" + std::to_string(catalogVersion) + "::layerVersions";
@@ -132,7 +132,7 @@ boost::optional<model::Partitions> PartitionsCacheRepository::Get(
 void PartitionsCacheRepository::Put(int64_t catalogVersion,
                                     const model::LayerVersions& layerVersions) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Put '%s'", hrn.c_str());
+  EDGE_SDK_LOG_INFO_F(kLogTag, "Put '%s'", hrn.c_str());
   cache_->Put(CreateKey(hrn, catalogVersion), layerVersions,
               [=]() { return olp::serializer::serialize(layerVersions); });
 }
@@ -141,7 +141,7 @@ boost::optional<model::LayerVersions> PartitionsCacheRepository::Get(
     int64_t catalogVersion) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, catalogVersion);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Get '%s'", key.c_str());
+  EDGE_SDK_LOG_INFO_F(kLogTag, "Get '%s'", key.c_str());
   auto cachedLayerVersions =
       cache_->Get(key, [](const std::string& serializedObject) {
         return parser::parse<model::LayerVersions>(serializedObject);
@@ -155,7 +155,7 @@ boost::optional<model::LayerVersions> PartitionsCacheRepository::Get(
 void PartitionsCacheRepository::Clear(const std::string& layer_id) {
   std::string hrn(hrn_.ToCatalogHRNString());
   auto key = CreateKey(hrn, layer_id, boost::none);
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "Clear '%s'", key.c_str());
+  EDGE_SDK_LOG_INFO_F(kLogTag, "Clear '%s'", key.c_str());
   cache_->RemoveKeysWithPrefix(key);
 }
 
@@ -163,7 +163,7 @@ void PartitionsCacheRepository::ClearPartitions(
     const PartitionsRequest& request,
     const std::vector<std::string>& partitionIds) {
   std::string hrn(hrn_.ToCatalogHRNString());
-  EDGE_SDK_LOG_TRACE_F(kLogTag, "ClearPartitions '%s'", hrn.c_str());
+  EDGE_SDK_LOG_INFO_F(kLogTag, "ClearPartitions '%s'", hrn.c_str());
   auto cachedPartitions = Get(request, partitionIds);
   // Partitions not processed here are not cached to begin with.
   for (auto partition : cachedPartitions.GetPartitions()) {

--- a/scripts/linux/fv/gitlab-olp-dataservice-read-test.sh
+++ b/scripts/linux/fv/gitlab-olp-dataservice-read-test.sh
@@ -2,4 +2,4 @@
 
 echo ">>> Core - SOURCE DATASERVICE READ Test ... >>>"
 source $FV_HOME/olp-dataservice-read-test.variables
-$REPO_HOME/build/olp-cpp-sdk-dataservice-read/test/unit/olp-dataservice-read-test --gtest_output="xml:$REPO_HOME/reports/olp-dataservice-read-test-report.xml" --gtest_filter="-TestMock/CatalogClientMockTest.GetPartitions403CacheClear/0"
+$REPO_HOME/build/olp-cpp-sdk-dataservice-read/test/unit/olp-dataservice-read-test --gtest_output="xml:$REPO_HOME/reports/olp-dataservice-read-test-report.xml"

--- a/scripts/linux/psv/travis_test_psv.sh
+++ b/scripts/linux/psv/travis_test_psv.sh
@@ -16,7 +16,7 @@ $CPP_TEST_SOURCE_CORE/network/olp-core-network-test --gtest_output="xml:report4.
 echo ">>> Core - Thread Test ... >>>"
 $CPP_TEST_SOURCE_CORE/thread/thread-test --gtest_output="xml:report5.xml"
 echo ">>> Dataservice read Test ... >>>"
-$CPP_TEST_SOURCE_DARASERVICE_READ/unit/olp-dataservice-read-test --gtest_output="xml:report6.xml" --gtest_filter=-"TestOnline/*":"*GetPartitions403CacheClear*"
+$CPP_TEST_SOURCE_DARASERVICE_READ/unit/olp-dataservice-read-test --gtest_output="xml:report6.xml" --gtest_filter=-"TestOnline/*"
 echo ">>> Dataservice write Test ... >>>"
 $CPP_TEST_SOURCE_DARASERVICE_WRITE/olp-dataservice-write-test --gtest_output="xml:report7.xml" --gtest_filter=-"*Online*":"TestCacheMock*"
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
When adding a layers partition metadata response to the cache the
key is hrn::layer::version::partitions. In case we receive a 403 error
we try to delete the entire entry from the cache with RemoveKeysWithPrefix()
were the key was hrn::layer::::partitions which didn't work as the entries
include version also. Changing the key in case no version is provided to
hrn::layer:: which will get successfull prefix comparison in the cache impl.

Relates-to: OLPEDGE-643

Signed-off-by: Andrei Popescu <andrei.popescu@here.com>