### PR TITLE
Temporary change network factory method to produce shared_ptr.

### DIFF
--- a/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
+++ b/olp-cpp-sdk-core/include/olp/core/client/OlpClientSettingsFactory.h
@@ -50,7 +50,7 @@ class CORE_API OlpClientSettingsFactory final {
    * which is defaulted to platform-specific implementation.
    * @return An instance of Network.
    */
-  static std::unique_ptr<http::Network> CreateDefaultNetworkRequestHandler(
+  static std::shared_ptr<http::Network> CreateDefaultNetworkRequestHandler(
       size_t max_requests_count = 30u);
 };
 

--- a/olp-cpp-sdk-core/include/olp/core/http/Network.h
+++ b/olp-cpp-sdk-core/include/olp/core/http/Network.h
@@ -86,7 +86,7 @@ class CORE_API Network {
 /**
  * @brief Create default Network implementation.
  */
-CORE_API std::unique_ptr<Network> CreateDefaultNetwork(size_t max_requests_count);
+CORE_API std::shared_ptr<Network> CreateDefaultNetwork(size_t max_requests_count);
 
 }  // namespace http
 }  // namespace olp

--- a/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
+++ b/olp-cpp-sdk-core/src/client/OlpClientSettingsFactory.cpp
@@ -32,7 +32,7 @@ OlpClientSettingsFactory::CreateDefaultTaskScheduler(size_t thread_count) {
   return std::make_unique<thread::ThreadPoolTaskScheduler>(thread_count);
 }
 
-std::unique_ptr<http::Network>
+std::shared_ptr<http::Network>
 OlpClientSettingsFactory::CreateDefaultNetworkRequestHandler(size_t max_requests_count) {
   return http::CreateDefaultNetwork(max_requests_count);
 }

--- a/olp-cpp-sdk-core/src/http/Network.cpp
+++ b/olp-cpp-sdk-core/src/http/Network.cpp
@@ -19,7 +19,6 @@
 
 #include "olp/core/http/Network.h"
 
-#include "olp/core/porting/make_unique.h"
 #include "olp/core/utils/WarningWorkarounds.h"
 
 #ifdef NETWORK_HAS_CURL
@@ -35,20 +34,18 @@
 namespace olp {
 namespace http {
 
-CORE_API std::unique_ptr<Network> CreateDefaultNetwork(size_t max_requests_count) {
+CORE_API std::shared_ptr<Network> CreateDefaultNetwork(
+    size_t max_requests_count) {
+  CORE_UNUSED(max_requests_count);
 #ifdef NETWORK_HAS_CURL
-  CORE_UNUSED(max_requests_count);
-  return std::make_unique<NetworkCurl>();
+  return std::make_shared<NetworkCurl>();
 #elif NETWORK_HAS_ANDROID
-  CORE_UNUSED(max_requests_count);
-  return std::make_unique<NetworkAndroid>();
+  return std::make_shared<NetworkAndroid>();
 #elif NETWORK_HAS_IOS
-  return std::make_unique<OLPNetworkIOS>(max_requests_count);
+  return std::make_shared<OLPNetworkIOS>(max_requests_count);
 #elif NETWORK_HAS_WINHTTP
-  CORE_UNUSED(max_requests_count);
-  return std::make_unique<NetworkWinHttp>();
-#else 
-  CORE_UNUSED(max_requests_count);
+  return std::make_shared<NetworkWinHttp>();
+#else
   static_assert(false, "No default network implementation provided");
 #endif
 }


### PR DESCRIPTION
Changed network factory method to produce a shared_ptr instead of unique_ptr.
Currently network implementation are derived from std::enable_shared_from_this
and it requires to be a shared_ptr.

Relates-To: OLPEDGE-543

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>