### PR TITLE
Fixed problem with inability to send new requests with NetworkAndroid

### DIFF
--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.h
@@ -196,6 +196,7 @@ class NetworkAndroid : public Network,
   jint unique_id_;
 
   bool started_;
+  bool initialized_;
   std::condition_variable run_thread_ready_cv_;
 
   RequestId request_id_counter_{


### PR DESCRIPTION
Fixed bug with inability to send the requests because NetworkAndroid wasn't initialized.

Relates to: OLPEDGE-371, OLPEDGE-543

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>