### PR TITLE
Fixed data race when generating NetworkAndroid's unique id

### DIFF
--- a/olp-cpp-sdk-core/src/http/android/HttpClient.java
+++ b/olp-cpp-sdk-core/src/http/android/HttpClient.java
@@ -37,6 +37,7 @@ import java.net.URLConnection;
 import java.net.UnknownHostException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -51,7 +52,10 @@ public class HttpClient {
   public static final int TIMEOUT_ERROR = -7;
   public static final int THREAD_POOL_SIZE = 8;
 
-  private int uniqueId = (int) (System.currentTimeMillis() % 10000);
+  public static final int INVALID_ID = 0;
+
+  private static AtomicInteger uniqueIdCounter = new AtomicInteger(1);
+  private int uniqueId = INVALID_ID;
 
   public enum HttpVerb {
     GET,
@@ -548,7 +552,8 @@ public class HttpClient {
   }
 
   public int registerClient() {
-    return this.uniqueId++;
+    uniqueId = this.uniqueIdCounter.getAndIncrement();
+    return uniqueId;
   }
 
   public HttpTask send(

--- a/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
+++ b/olp-cpp-sdk-core/src/http/android/NetworkAndroid.cpp
@@ -88,7 +88,7 @@ NetworkAndroid::NetworkAndroid()
       jni_send_method_(nullptr),
       java_shutdown_method_(nullptr),
       obj_(nullptr),
-      unique_id_(-1),
+      unique_id_(0),
       started_(false),
       initialized_(false) {}
 
@@ -949,7 +949,7 @@ NetworkAndroid::ResponseData::ResponseData(
       status(status),
       count(count),
       offset(offset) {}
-      
+
 
 }  // namespace http
 }  // namespace olp


### PR DESCRIPTION
Fixed problem with `StreamLayerClientOnlineTest.ConcurrentPublishDifferentIngestApi` test, which
was deadlocked because of invalid NetworkAndroid uniqueId generating policy:
there was the data race that there are could be created several instances of NetworkAndroid,
which had same unique id, thus, it resulted that some requests were lost.

Relates to: OLPEDGE-697

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>