### PR TITLE
Keep network instance in unit tests alive until inner thread is running

### DIFF
--- a/olp-cpp-sdk-dataservice-write/test/unit/TestIndexLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/test/unit/TestIndexLayerClient.cpp
@@ -136,9 +136,15 @@ class IndexLayerClientTestBase : public ::testing::TestWithParam<bool> {
 
 class IndexLayerClientOnlineTest : public IndexLayerClientTestBase {
  protected:
-  virtual std::shared_ptr<IndexLayerClient> CreateIndexLayerClient() override {
-    auto network = olp::client::OlpClientSettingsFactory::
+  static std::shared_ptr<olp::http::Network> s_network;
+
+  static void SetUpTestSuite() {
+    s_network = olp::client::OlpClientSettingsFactory::
         CreateDefaultNetworkRequestHandler();
+  }
+
+  virtual std::shared_ptr<IndexLayerClient> CreateIndexLayerClient() override {
+    auto network = s_network;
 
     olp::authentication::Settings authentication_settings;
     authentication_settings.token_endpoint_url =
@@ -160,6 +166,11 @@ class IndexLayerClientOnlineTest : public IndexLayerClientTestBase {
         olp::client::HRN{GetTestCatalog()}, settings);
   }
 };
+
+// Static network instance is necessary as it needs to outlive any created
+// clients. This is a known limitation as triggered send requests capture the
+// network instance inside the callbacks.
+std::shared_ptr<olp::http::Network> IndexLayerClientOnlineTest::s_network;
 
 INSTANTIATE_TEST_SUITE_P(TestOnline, IndexLayerClientOnlineTest,
                          ::testing::Values(true));

--- a/olp-cpp-sdk-dataservice-write/test/unit/TestStreamLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/test/unit/TestStreamLayerClient.cpp
@@ -192,10 +192,16 @@ class StreamLayerClientTestBase : public ::testing::TestWithParam<bool> {
 
 class StreamLayerClientOnlineTest : public StreamLayerClientTestBase {
  protected:
+  static std::shared_ptr<olp::http::Network> s_network;
+
+  static void SetUpTestSuite() {
+    s_network = olp::client::OlpClientSettingsFactory::
+        CreateDefaultNetworkRequestHandler();
+  }
+
   virtual std::shared_ptr<StreamLayerClient> CreateStreamLayerClient()
       override {
-    auto network = olp::client::OlpClientSettingsFactory::
-        CreateDefaultNetworkRequestHandler();
+    auto network = s_network;
 
     olp::authentication::Settings authentication_settings;
     authentication_settings.token_endpoint_url =
@@ -216,6 +222,11 @@ class StreamLayerClientOnlineTest : public StreamLayerClientTestBase {
         olp::client::HRN{GetTestCatalog()}, settings);
   }
 };
+
+// Static network instance is necessary as it needs to outlive any created
+// clients. This is a known limitation as triggered send requests capture the
+// network instance inside the callbacks.
+std::shared_ptr<olp::http::Network> StreamLayerClientOnlineTest::s_network;
 
 INSTANTIATE_TEST_SUITE_P(TestOnline, StreamLayerClientOnlineTest,
                          ::testing::Values(true));
@@ -1250,10 +1261,16 @@ TEST_P(StreamLayerClientMockTest, DISABLED_SDIIConcurrentPublishSameIngestApi) {
 
 class StreamLayerClientCacheOnlineTest : public StreamLayerClientOnlineTest {
  protected:
+  static std::shared_ptr<olp::http::Network> s_network;
+
+  static void SetUpTestSuite() {
+    s_network = olp::client::OlpClientSettingsFactory::
+        CreateDefaultNetworkRequestHandler();
+  }
+
   virtual std::shared_ptr<StreamLayerClient> CreateStreamLayerClient()
       override {
-    auto network = olp::client::OlpClientSettingsFactory::
-        CreateDefaultNetworkRequestHandler();
+    auto network = s_network;
 
     olp::authentication::Settings authentication_settings;
     authentication_settings.token_endpoint_url =
@@ -1290,6 +1307,11 @@ class StreamLayerClientCacheOnlineTest : public StreamLayerClientOnlineTest {
   std::shared_ptr<olp::cache::DefaultCache> disk_cache_;
   FlushSettings flush_settings_;
 };
+
+// Static network instance is necessary as it needs to outlive any created
+// clients. This is a known limitation as triggered send requests capture the
+// network instance inside the callbacks.
+std::shared_ptr<olp::http::Network> StreamLayerClientCacheOnlineTest::s_network;
 
 INSTANTIATE_TEST_SUITE_P(TestCacheOnline, StreamLayerClientCacheOnlineTest,
                          ::testing::Values(true));

--- a/olp-cpp-sdk-dataservice-write/test/unit/TestVersionedLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/test/unit/TestVersionedLayerClient.cpp
@@ -78,16 +78,20 @@ TEST_P(VersionedLayerClientOfflineTest, StartBatchRequestTest) {
 }
 
 class VersionedLayerClientOnlineTest : public VersionedLayerClientTest {
- public:
  protected:
+  static std::shared_ptr<olp::http::Network> s_network;
+
+  static void SetUpTestSuite() {
+    s_network = olp::client::OlpClientSettingsFactory::
+        CreateDefaultNetworkRequestHandler();
+  }
+
   virtual void SetUp() override { client_ = createVersionedLayerClient(); }
 
   virtual void TearDown() override { client_ = nullptr; }
 
   std::shared_ptr<VersionedLayerClient> createVersionedLayerClient() {
-    auto network = olp::client::OlpClientSettingsFactory::
-        CreateDefaultNetworkRequestHandler();
-
+    auto network = s_network;
     olp::authentication::Settings authentication_settings;
     authentication_settings.token_endpoint_url =
         CustomParameters::getArgument(kEndpoint);
@@ -110,6 +114,11 @@ class VersionedLayerClientOnlineTest : public VersionedLayerClientTest {
 
   std::shared_ptr<VersionedLayerClient> client_;
 };
+
+// Static network instance is necessary as it needs to outlive any created
+// clients. This is a known limitation as triggered send requests capture the
+// network instance inside the callbacks.
+std::shared_ptr<olp::http::Network> VersionedLayerClientOnlineTest::s_network;
 
 INSTANTIATE_TEST_SUITE_P(TestOnline, VersionedLayerClientOnlineTest,
                          ::testing::Values(true));

--- a/olp-cpp-sdk-dataservice-write/test/unit/TestVolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/test/unit/TestVolatileLayerClient.cpp
@@ -108,10 +108,16 @@ class VolatileLayerClientTestBase : public ::testing::TestWithParam<bool> {
 
 class VolatileLayerClientOnlineTest : public VolatileLayerClientTestBase {
  protected:
+  static std::shared_ptr<olp::http::Network> s_network;
+
+  static void SetUpTestSuite() {
+    s_network = olp::client::OlpClientSettingsFactory::
+        CreateDefaultNetworkRequestHandler();
+  }
+
   virtual std::shared_ptr<VolatileLayerClient> CreateVolatileLayerClient()
       override {
-    auto network = olp::client::OlpClientSettingsFactory::
-        CreateDefaultNetworkRequestHandler();
+    auto network = s_network;
 
     olp::authentication::Settings authentication_settings;
     authentication_settings.token_endpoint_url =
@@ -133,6 +139,11 @@ class VolatileLayerClientOnlineTest : public VolatileLayerClientTestBase {
         olp::client::HRN{GetTestCatalog()}, settings);
   }
 };
+
+// Static network instance is necessary as it needs to outlive any created
+// clients. This is a known limitation as triggered send requests capture the
+// network instance inside the callbacks.
+std::shared_ptr<olp::http::Network> VolatileLayerClientOnlineTest::s_network;
 
 INSTANTIATE_TEST_SUITE_P(TestOnline, VolatileLayerClientOnlineTest,
                          ::testing::Values(true));


### PR DESCRIPTION
Network is instantiated once for every test suite and reused in all tests of that suite.

Relates-to: OLPEDGE-544
Signed-off-by: Serhii Lysenko <ext-serhii.lysenko@here.com>