### PR TITLE
Fix mutex double locking when the callback is executed sync.

### DIFF
--- a/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/IndexLayerClientImpl.cpp
@@ -133,10 +133,7 @@ olp::client::CancellationToken IndexLayerClientImpl::InitApiClients(
     cancel_context->ExecuteOrCancelled(blobApi_function, cancel_function);
   };
 
-  auto configApi_function = [=]() -> olp::client::CancellationToken {
-    return ApiClientLookup::LookupApi(self->apiclient_config_, "config", "v1",
-                                      self->catalog_, configApi_callback);
-  };
+  ul.unlock();
 
   return ApiClientLookup::LookupApi(apiclient_config_, "config", "v1", catalog_,
                                     configApi_callback);

--- a/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VersionedLayerClientImpl.cpp
@@ -151,6 +151,8 @@ olp::client::CancellationToken VersionedLayerClientImpl::InitApiClients(
     cancel_context->ExecuteOrCancelled(configApi_function, cancel_function);
   };
 
+  ul.unlock();
+
   return ApiClientLookup::LookupApi(apiclient_metadata_, "metadata", "v1",
                                     catalog_, metadataApi_callback);
 }

--- a/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
+++ b/olp-cpp-sdk-dataservice-write/src/VolatileLayerClientImpl.cpp
@@ -165,10 +165,7 @@ olp::client::CancellationToken VolatileLayerClientImpl::InitApiClients(
     cancel_context->ExecuteOrCancelled(metadataApi_function, cancel_function);
   };
 
-  auto configApi_function = [=]() -> olp::client::CancellationToken {
-    return ApiClientLookup::LookupApi(self->apiclient_config_, "config", "v1",
-                                      self->catalog_, configApi_callback);
-  };
+  ul.unlock();
 
   return ApiClientLookup::LookupApi(apiclient_config_, "config", "v1", catalog_,
                                     configApi_callback);


### PR DESCRIPTION
Fix mutex double locking when the callback is executed sync.

Relates-To: OLPEDGE-667

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>