### PR TITLE
Disabled StartBatchDeleteClientTest in volatile layer client test

### DIFF
--- a/olp-cpp-sdk-dataservice-write/test/unit/TestVolatileLayerClient.cpp
+++ b/olp-cpp-sdk-dataservice-write/test/unit/TestVolatileLayerClient.cpp
@@ -310,7 +310,11 @@ TEST_P(VolatileLayerClientOnlineTest, PublishToBatchInvalidTest) {
   ASSERT_FALSE(publishToBatchResponse.IsSuccessful());
 }
 
-TEST_P(VolatileLayerClientOnlineTest, StartBatchDeleteClientTest) {
+// Sometimes we receive the 500 internal server error,
+// thus looks loke the problem is on the server side.
+// Please, re-enable this test when switched to mocked server or
+// when the server will be more steady for testing
+TEST_P(VolatileLayerClientOnlineTest, DISABLED_StartBatchDeleteClientTest) {
   auto volatileClient = CreateVolatileLayerClient();
   auto response =
       volatileClient


### PR DESCRIPTION
Disabled flaky VolatileLayerClientOnlineTest.StartBatchDeleteClientTest because we receive the 500 internal server error.

Related-to: OLPEDGE-697, OLPEDGE-709

Signed-off-by: Bohdan Kurylovych <ext-bohdan.kurylovych@here.com>