### PR TITLE
Removed outdated references from CMake

### DIFF
--- a/olp-cpp-sdk-core/cmake/android.cmake
+++ b/olp-cpp-sdk-core/cmake/android.cmake
@@ -15,13 +15,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 if(NOT ANDROID)
-    set(NETWORK_ANDROID_SOURCES)
     set(NETWORK_ANDROID_LIBRARIES)
     return()
 endif()
 
-aux_source_directory(${CMAKE_CURRENT_LIST_DIR}/../src/network/android NETWORK_ANDROID_SOURCES)
-set(NETWORK_ANDROID_SOURCES ${NETWORK_ANDROID_SOURCES} ${CMAKE_CURRENT_LIST_DIR}/../src/network/socket/NetworkConnectivitySocketImpl.cpp)
 add_definitions(-DNETWORK_HAS_ANDROID)
 set(NETWORK_ANDROID_LIBRARIES ${ANDROID_LIBRARY})
 include_directories(${ANDROID_INCLUDE_DIR})

--- a/olp-cpp-sdk-core/cmake/curl.cmake
+++ b/olp-cpp-sdk-core/cmake/curl.cmake
@@ -16,8 +16,6 @@
 # License-Filename: LICENSE
 
 if(CURL_FOUND AND NOT NETWORK_NO_CURL)
-    aux_source_directory(${CMAKE_CURRENT_LIST_DIR}/../src/network/curl NETWORK_CURL_SOURCES)
-    set(NETWORK_CURL_SOURCES ${NETWORK_CURL_SOURCES} ${CMAKE_CURRENT_LIST_DIR}/../src/network/socket/NetworkConnectivitySocketImpl.cpp)
     set(EDGE_SDK_HTTP_CURL_SOURCES ${EDGE_SDK_HTTP_CURL_SOURCES} ${CMAKE_CURRENT_LIST_DIR}/../src/http/curl/NetworkCurl.cpp)
 
     add_definitions(-DNETWORK_HAS_CURL)
@@ -54,6 +52,6 @@ if(CURL_FOUND AND NOT NETWORK_NO_CURL)
     endif()
 
 else()
-    set(NETWORK_CURL_SOURCES)
+    set(EDGE_SDK_HTTP_CURL_SOURCES)
     set(NETWORK_CURL_LIBRARIES)
 endif()

--- a/olp-cpp-sdk-core/cmake/ios.cmake
+++ b/olp-cpp-sdk-core/cmake/ios.cmake
@@ -15,14 +15,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 if(IOS)
-    aux_source_directory(${CMAKE_CURRENT_LIST_DIR}/../src/network/ios NETWORK_IOS_SOURCES)
-    ### To show header files in IDEs
-    file(GLOB_RECURSE NETWORK_IOS_INTERNAL_INCLUDES "*.h" "*.inl")
-    set(NETWORK_IOS_SOURCES
-        ${NETWORK_IOS_SOURCES}
-        ${NETWORK_IOS_INTERNAL_INCLUDES}
-    )
-
     set(EDGE_SDK_HTTP_IOS_SOURCES
         "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPNetworkIOS.mm"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/http/ios/OLPNetworkIOS.h"
@@ -38,5 +30,5 @@ if(IOS)
 
     add_definitions(-DNETWORK_HAS_IOS)
 else()
-    set(NETWORK_IOS_SOURCES)
+    set(EDGE_SDK_HTTP_IOS_SOURCES)
 endif()

--- a/olp-cpp-sdk-core/cmake/winhttp.cmake
+++ b/olp-cpp-sdk-core/cmake/winhttp.cmake
@@ -15,12 +15,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 if(WIN32)
-    file(GLOB NETWORK_WINHTTP_SOURCES "${CMAKE_CURRENT_LIST_DIR}/../src/network/winhttp/*.cpp")
-    set(NETWORK_WINHTTP_SOURCES ${NETWORK_WINHTTP_SOURCES} ${CMAKE_CURRENT_LIST_DIR}/../src/network/socket/NetworkConnectivitySocketImpl.cpp)
-
     set(EDGE_SDK_HTTP_WIN_SOURCES
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/winhttp/NetworkWinHttp.cpp"
-        "${CMAKE_CURRENT_SOURCE_DIR}/src/http/winhttp/NetworkWinHttp.h"
+        "${CMAKE_CURRENT_LIST_DIR}/../src/http/winhttp/NetworkWinHttp.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/../src/http/winhttp/NetworkWinHttp.h"
     )
 
     add_definitions(-DNETWORK_HAS_WINHTTP)
@@ -34,6 +31,6 @@ if(WIN32)
     endif()
     set(NETWORK_WINHTTP_LIBRARIES ${NETWORK_WINHTTP_LIBRARIES} Ws2_32)
 else()
-    set(NETWORK_WINHTTP_SOURCES)
+    set(EDGE_SDK_HTTP_WIN_SOURCES)
     set(NETWORK_WINHTTP_LIBRARIES)
 endif()


### PR DESCRIPTION
Removed outdated references from CMake.

Fixed incorrect paths for winhttp

Relates-To: OLPEDGE-683

Signed-off-by: Mykhailo Kuchma <ext-mykhailo.kuchma@here.com>