### PR TITLE
Make core tests a part of olp-cpp-sdk-core project

### DIFF
--- a/olp-cpp-sdk-core/tests/CMakeLists.txt
+++ b/olp-cpp-sdk-core/tests/CMakeLists.txt
@@ -17,8 +17,6 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project(olp-cpp-sdk-core-tests VERSION 0.7.0)
-
 set(OLP_CPP_SDK_CORE_TESTS_SOURCES
     ./cache/DefaultCacheTest.cpp
     ./cache/InMemoryCacheTest.cpp


### PR DESCRIPTION
Make core tests a part of olp-cpp-sdk-core project

Relates-to: OLPEDGE-591